### PR TITLE
BB-BONE-BACONE-00A0.dts: hardware ip should use gpio0_22 for P8.19

### DIFF
--- a/src/arm/BB-BONE-BACONE-00A0.dts
+++ b/src/arm/BB-BONE-BACONE-00A0.dts
@@ -33,7 +33,7 @@
 		"P9.22",	/* shift: gpio0_2 CLOCK */
 		/* the hardware ip uses */
 		"tscadc",
-		"gpio0_23",
+		"gpio0_22",
 		"ehrpwm1A",
 		"ehrpwm1B",
 		"eCAP0_in_PWM0_out",


### PR DESCRIPTION
Fixes https://github.com/RobertCNelson/bb.org-overlays/issues/3