### PR TITLE
avoid uart1.i2c2 pins in BB-UART1, add additional count_mode support in eqep

### DIFF
--- a/include/dt-bindings/board/am335x-bbw-bbb-base.h
+++ b/include/dt-bindings/board/am335x-bbw-bbb-base.h
@@ -101,3 +101,4 @@
 #define BONE_P9_42B 0x1A0
 
 #endif
+

--- a/include/dt-bindings/gpio/gpio.h
+++ b/include/dt-bindings/gpio/gpio.h
@@ -13,3 +13,4 @@
 #define GPIO_ACTIVE_LOW 1
 
 #endif
+

--- a/include/dt-bindings/pinctrl/am33xx.h
+++ b/include/dt-bindings/pinctrl/am33xx.h
@@ -7,9 +7,10 @@
 
 #include <dt-bindings/pinctrl/omap.h>
 
+#undef  INPUT_EN
+
 /* am33xx specific mux bit defines */
 #define PULL_DISABLE		(1 << 3)
-#undef  INPUT_EN
 #define INPUT_EN		(1 << 5)
 #define SLEWCTRL_SLOW		(1 << 6)
 #define SLEWCTRL_FAST		0

--- a/include/dt-bindings/pinctrl/am33xx.h
+++ b/include/dt-bindings/pinctrl/am33xx.h
@@ -8,10 +8,8 @@
 #include <dt-bindings/pinctrl/omap.h>
 
 /* am33xx specific mux bit defines */
-#undef PULL_ENA
-#undef INPUT_EN
-
 #define PULL_DISABLE		(1 << 3)
+#undef  INPUT_EN
 #define INPUT_EN		(1 << 5)
 #define SLEWCTRL_SLOW		(1 << 6)
 #define SLEWCTRL_FAST		0

--- a/src/arm/BB-I2C1-00A0.dts
+++ b/src/arm/BB-I2C1-00A0.dts
@@ -13,53 +13,55 @@
 / {
 	compatible = "ti,beaglebone", "ti,beaglebone-black", "ti,beaglebone-green";
 
-	/* identification */
+	// identification
 	part-number = "BB-I2C1";
 	version = "00A0";
 
-	/* state the resources this cape uses */
+	// resources this cape uses
 	exclusive-use =
-		/* the pin header uses */
-		"P9.18",	/* i2c1_sda */
-		"P9.17",	/* i2c1_scl */
-		/* the hardware ip uses */
-		"i2c1";
+		"P9.18",		// i2c1_sda
+		"P9.17",		// i2c1_scl
+
+		"i2c1";		// hardware ip used
+
 
 	fragment@0 {
 		target = <&am33xx_pinmux>;
 		__overlay__ {
 			bb_i2c1_pins: pinmux_bb_i2c1_pins {
 				pinctrl-single,pins = <
-					0x158 0x72	/* spi0_d1.i2c1_sda, SLEWCTRL_SLOW | INPUT_PULLUP | MODE2 */
-					0x15c 0x72	/* spi0_cs0.i2c1_scl, SLEWCTRL_SLOW | INPUT_PULLUP | MODE2 */
+					BONE_P9_18 0x72	// spi0_d1.i2c1_sda, SLEWCTRL_SLOW | INPUT_PULLUP | MODE2
+					BONE_P9_17 0x72	// spi0_cs0.i2c1_scl, SLEWCTRL_SLOW | INPUT_PULLUP | MODE2
 				>;
 			};
 		};
 	};
 
 	fragment@1 {
-		target = <&i2c1>;	/* i2c1 is numbered correctly */
+		target = <&i2c1>;	// i2c1 is numbered correctly
 		__overlay__ {
 			status = "okay";
 			pinctrl-names = "default";
 			pinctrl-0 = <&bb_i2c1_pins>;
 
-			/* this is the configuration part */
+			// configuration start
 			clock-frequency = <100000>;
 
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			/* add any i2c devices on the bus here */
+			// add any i2c devices on the bus here
 
-			// commented out example of a touchscreen (taken from BB-BONE-LCD7-01-00A4) */
-			// maxtouch@4a {
-			//	compatible = "mXT224";
-			//	reg = <0x4a>;
-			//	interrupt-parent = <&gpio4>;
-			//	interrupts = <19 0x0>;
-			//	atmel,irq-gpio = <&gpio4 19 0>;
-			// };
+			// commented out example of a touchscreen (taken from BB-BONE-LCD7-01-00A4)
+			/*
+			maxtouch@4a {
+				compatible = "mXT224";
+				reg = <0x4a>;
+				interrupt-parent = <&gpio4>;
+				interrupts = <19 0x0>;
+				atmel,irq-gpio = <&gpio4 19 0>;
+			};
+			*/
 		};
 	};
 };

--- a/src/arm/BB-I2C1-00A0.dts
+++ b/src/arm/BB-I2C1-00A0.dts
@@ -7,8 +7,10 @@
  * it under the terms of the GNU General Public License version 2 as
  * published by the Free Software Foundation.
  */
-/dts-v1/;
-/plugin/;
+/dts-v1/  /plugin/;
+
+#include <dt-bindings/board/am335x-bbw-bbb-base.h>
+#include <dt-bindings/pinctrl/am33xx.h>
 
 / {
 	compatible = "ti,beaglebone", "ti,beaglebone-black", "ti,beaglebone-green";

--- a/src/arm/BB-UART1-00A0.dts
+++ b/src/arm/BB-UART1-00A0.dts
@@ -23,8 +23,8 @@
 	exclusive-use =
 		"P9.24",		// uart1_txd
 		"P9.26",		// uart1_rxd
-		"P9.19",		// uart1_rtsn
-		"P9.20",		// uart1_ctsn
+	//	"P9.19",		// uart1_rtsn	conflict with uart1_rtsn.i2c2_scl, i.e. the cape EEPROMS
+	//	"P9.20",		// uart1_ctsn	conflict with uart1_ctsn.i2c2_sda, i.e. the cape EEPROMS
 
 		"uart1";		// hardware ip used
 

--- a/src/arm/BB-UART2-00A0.dts
+++ b/src/arm/BB-UART2-00A0.dts
@@ -23,8 +23,8 @@
 	exclusive-use =
 		"P9.21",		// uart2_txd
 		"P9.22",		// uart2_rxd
-	//	"P8.38",		// uart2_rtsn  conflict with uart5
-	//	"P8.37",		// uart2_ctsn  conflict with uart5
+		"P8.38",		// uart2_rtsn  conflict with uart5
+		"P8.37",		// uart2_ctsn  conflict with uart5
 
 		"uart2";		// hardware ip used
 

--- a/src/arm/BB-UART4-00A0.dts
+++ b/src/arm/BB-UART4-00A0.dts
@@ -31,8 +31,8 @@
 		__overlay__ {
 			bb_uart4_pins: pinmux_bb_uart4_pins {
 				pinctrl-single,pins = <
-					BONE_P9_11 (PIN_INPUT  | MUX_MODE6)	// gpmc_wait0.uart4_rxd_mux2
 					BONE_P9_13 (PIN_OUTPUT | MUX_MODE6)	// gpmc_wpn.uart4_txd_mux2
+					BONE_P9_11 (PIN_INPUT  | MUX_MODE6)	// gpmc_wait0.uart4_rxd_mux2
 				>;
 			};
 		};

--- a/src/arm/BB-UART5-00A0.dts
+++ b/src/arm/BB-UART5-00A0.dts
@@ -32,8 +32,8 @@
 		__overlay__ {
 			bb_uart5_pins: pinmux_bb_uart5_pins {
 				pinctrl-single,pins = <
-					BONE_P8_38 (PIN_INPUT  | MUX_MODE4)	// lcd_data9.uart5_rxd
 					BONE_P8_37 (PIN_OUTPUT | MUX_MODE4)	// lcd_data8.uart5_txd
+					BONE_P8_38 (PIN_INPUT  | MUX_MODE4)	// lcd_data9.uart5_rxd
 				>;
 			};
 		};

--- a/src/arm/bone_eqep0-00A0.dts
+++ b/src/arm/bone_eqep0-00A0.dts
@@ -22,14 +22,14 @@
 	part-number = "bone_eqep0";
 	version	    = "00A0";
 
-	// state the resources this cape uses
+	// resources this cape uses
 	exclusive-use =
 		"P9.42.1",	// EQEP0A_in
 		"P9.27",		// EQEP0B_in
 		"P9.41",		// EQEP0_index
 		"P9.25",		// EQEP0_strobe
 
-		"eqep0";		// the hardware ip used
+		"eqep0";		// hardware ip used
 
 	fragment@0 {
 		target = <&am33xx_pinmux>;
@@ -63,8 +63,8 @@
 			swap_inputs = <0>; 	// swap channel A and B? (0 - no, 1 - yes)
 			invert_qa = <0>;   	// invert channel A input?
 			invert_qb = <0>;   	// invert channel B input?
-			invert_qi = <0>;   	// invert the index input?
-			invert_qs = <0>;   	// invert the strobe input?
+			invert_qi = <0>;   	// invert index input?
+			invert_qs = <0>;   	// invert strobe input?
 
 			status = "okay";
 		};

--- a/src/arm/bone_eqep0-00A0.dts
+++ b/src/arm/bone_eqep0-00A0.dts
@@ -58,8 +58,12 @@
 			pinctrl-names = "default";
 			pinctrl-0 = <&pinctrl_eqep0>;
 
-			count_mode = <1>;	// 0 -> Quadrature mode, normal 90 phase offset cha & chb.
-						// 1 -> Direction mode.  cha input = clock, chb input = direction
+			count_mode = <1>;	// count_mode is not userspace op_mode
+			// 0 -> Quadrature mode, normal 90 phase offset cha & chb.
+			// 1 -> Direction mode.  cha input = clock, chb input = direction
+			// 2 -> UP count mode for frequency measurement QDIR=1, ignore direction input
+			// 3 -> DOWN count mode for frequency measurement QDIR=0, ignore direction input
+
 			swap_inputs = <0>; 	// swap channel A and B? (0 - no, 1 - yes)
 			invert_qa = <0>;   	// invert channel A input?
 			invert_qb = <0>;   	// invert channel B input?

--- a/src/arm/bone_eqep1-00A0.dts
+++ b/src/arm/bone_eqep1-00A0.dts
@@ -57,8 +57,11 @@
 			pinctrl-names = "default";
 			pinctrl-0 = <&pinctrl_eqep1>;
 
-			count_mode = <1>;	// 0 -> Quadrature mode, normal 90 phase offset cha & chb.
-						// 1 -> Direction mode.  cha input = clock, chb input = direction
+			count_mode = <1>;	// count_mode is not userspace op_mode
+			// 0 -> Quadrature mode, normal 90 phase offset cha & chb.
+			// 1 -> Direction mode.  cha input = clock, chb input = direction
+			// 2 -> UP count mode for frequency measurement QDIR=1, ignore direction input
+			// 3 -> DOWN count mode for frequency measurement QDIR=0, ignore direction input
 			swap_inputs = <0>; 	// swap channel A and B (0 - no, 1 - yes)
 			invert_qa = <0>;		// invert channel A input?
 			invert_qb = <0>;   	// invert channel B input?

--- a/src/arm/bone_eqep1-00A0.dts
+++ b/src/arm/bone_eqep1-00A0.dts
@@ -22,14 +22,14 @@
 	part-number = "bone_eqep1";
 	version	    = "00A0";
 
-	// state the resources this cape uses
+	// resources this cape uses
 	exclusive-use =
 		"P8.35",		// EQEP1A_in
 		"P8.33",		// EQEP1B_in
 		"P8.31",		// EQEP1_index
 		"P8.32",		// EQEP1_strobe
 
-		"eqep1";		// the hardware ip used
+		"eqep1";		// hardware ip used
 
 	fragment@0 {
 		target = <&am33xx_pinmux>;
@@ -60,7 +60,7 @@
 
 			count_mode = <1>;	// 0 -> Quadrature mode, normal 90 phase offset cha & chb.
 						// 1 -> Direction mode.  cha input = clock, chb input = direction
-			swap_inputs = <0>; 	// swap channel A and channel B (0 - no, 1 - yes)
+			swap_inputs = <0>; 	// swap channel A and B (0 - no, 1 - yes)
 			invert_qa = <0>;		// invert channel A input?
 			invert_qb = <0>;   	// invert channel B input?
 			invert_qi = <0>;   	// invert index input?

--- a/src/arm/bone_eqep2-00A0.dts
+++ b/src/arm/bone_eqep2-00A0.dts
@@ -57,8 +57,12 @@
 			pinctrl-names = "default";
 			pinctrl-0 = <&pinctrl_eqep2>;
 
-			count_mode = <0>;  	// 0 -> Quadrature mode, normal 90 phase offset cha & chb.
-						// 1 -> Direction mode.  cha input = clock, chb input = direction
+			count_mode = <1>;	// count_mode is not userspace op_mode
+			// 0 -> Quadrature mode, normal 90 phase offset cha & chb.
+			// 1 -> Direction mode.  cha input = clock, chb input = direction
+			// 2 -> UP count mode for frequency measurement QDIR=1, ignore direction input
+			// 3 -> DOWN count mode for frequency measurement QDIR=0, ignore direction input
+
 			swap_inputs = <0>;	// swap channel A and B? (0 - no, 1 - yes)
 			invert_qa = <0>;		// invert channel A input?
 			invert_qb = <0>;		// invert channel B input?

--- a/src/arm/bone_eqep2-00A0.dts
+++ b/src/arm/bone_eqep2-00A0.dts
@@ -29,7 +29,7 @@
 		"P8.39",		// EQEP2_index
 		"P8.40",		// EQEP2_strobe
 
-		"eqep2";		// the hardware ip used
+		"eqep2";		// hardware ip used
 
 	fragment@0 {
 		target = <&am33xx_pinmux>;

--- a/src/arm/bone_eqep2b.dts
+++ b/src/arm/bone_eqep2b.dts
@@ -17,7 +17,7 @@
 / {
 	compatible = "ti,beaglebone", "ti,beaglebone-black";
 
-	/* identification */
+	// identification
 	part-number = "bone_eqep2";
 	version	    = "00A0";
 
@@ -28,7 +28,7 @@
 		"P8.16",		// EQEP2_index
 		"P8.15",		// EQEP2_strobe
 
-		"eqep2";		// the hardware ip used
+		"eqep2";		// hardware ip used
 
 	fragment@0 {
 		target = <&am33xx_pinmux>;
@@ -59,7 +59,7 @@
 			pinctrl-0 = <&pinctrl_eqep2>;
 
 			count_mode = <0>;	// 0 -> Quadrature mode, normal 90 phase offset cha & chb.
-						// 1 - Direction mode.  cha input = clock, chb input = direction
+						// 1 -> Direction mode.  cha input = clock, chb input = direction
 			swap_inputs = <0>;	// swap channel A and B? (0 - no, 1 - yes)
 			invert_qa = <1>;		// invert channel A input?
 			invert_qb = <1>;		// invert channel B input?

--- a/src/arm/bone_eqep2b.dts
+++ b/src/arm/bone_eqep2b.dts
@@ -59,11 +59,15 @@
 			pinctrl-names = "default";
 			pinctrl-0 = <&pinctrl_eqep2>;
 
-			count_mode = <0>;	// 0 -> Quadrature mode, normal 90 phase offset cha & chb.
-						// 1 -> Direction mode.  cha input = clock, chb input = direction
+			count_mode = <1>;	// count_mode is not userspace op_mode
+			// 0 -> Quadrature mode, normal 90 phase offset cha & chb.
+			// 1 -> Direction mode.  cha input = clock, chb input = direction
+			// 2 -> UP count mode for frequency measurement QDIR=1, ignore direction input
+			// 3 -> DOWN count mode for frequency measurement QDIR=0, ignore direction input
+
 			swap_inputs = <0>;	// swap channel A and B? (0 - no, 1 - yes)
-			invert_qa = <1>;		// invert channel A input?
-			invert_qb = <1>;		// invert channel B input?
+			invert_qa = <0>;		// invert channel A input?
+			invert_qb = <0>;		// invert channel B input?
 			invert_qi = <0>;		// invert index input?
 			invert_qs = <0>;		// invert strobe input?
 


### PR DESCRIPTION
I have a kernel patch for tieqep.c which supports count_mode <2> & <3>.  It still needs some code formatting, as the original driver could never be accepted into mainline since it uses C++ comments and spaced instead of tabs.

The advantage of count_modes 2 & 3 are that the direction input is fixed and you don't need a pin to determine direction.   Useful for frequency inputs.  count_mode is not the same as userspace "mode" (absolute vs. relative).  Three of the count_modes all pertain typically to userspace "mode" == relative.