### PR TITLE
ensure installation directory exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ all_arch: $(ARCH_DTB)
 
 PHONY += install_arch
 install_arch: $(ARCH_DTBO)
+	mkdir -p $(DESTDIR)/lib/firmware/
 	cp -v $(obj)/*.dtbo $(DESTDIR)/lib/firmware/
 
 RCS_FIND_IGNORE := \( -name SCCS -o -name BitKeeper -o -name .svn -o -name CVS \


### PR DESCRIPTION
If ```/lib/firmware``` doesn't exist, ```make install``` fails:
```
cp -v src/arm/*.dtbo /lib/firmware/
cp: target ‘/lib/firmware/’ is not a directory
Makefile:142: recipe for target 'install_arch' failed
make[1]: *** [install_arch] Error 1
Makefile:88: recipe for target 'install_arm' failed
make: *** [install_arm] Error 2
```