### PR TITLE
enable eqep1 for pins p8.33 and p8.35

### DIFF
--- a/src/arm/cape-universala-00A0.dts
+++ b/src/arm/cape-universala-00A0.dts
@@ -159,7 +159,9 @@
         "spi0",
         "dcan0",
         "dcan1",
-
+        "eqep0",
+        "eqep1",
+        "eqep2",
         "pru0",
         "pru1",
         "pruss";
@@ -543,6 +545,9 @@
                 pinctrl-single,pins = <0x0D4  0x37>; };     /* Mode 7, Pull-Up, RxActive */
             P8_33_gpio_pd_pin: pinmux_P8_33_gpio_pd_pin {
                 pinctrl-single,pins = <0x0D4  0x27>; };     /* Mode 7, Pull-Down, RxActive */
+            P8_33_qep_pin: pinmux_P8_33_qep_pin {
+                pinctrl-single,pins = <0x0D4  0x22>; };     /* Mode 2, Pull-Down, RxActive */
+
 
             /* P8_34 (ZCZ ball U4 ) hdmi    */
             P8_34_default_pin: pinmux_P8_34_default_pin {
@@ -565,6 +570,9 @@
                 pinctrl-single,pins = <0x0D0  0x37>; };     /* Mode 7, Pull-Up, RxActive */
             P8_35_gpio_pd_pin: pinmux_P8_35_gpio_pd_pin {
                 pinctrl-single,pins = <0x0D0  0x27>; };     /* Mode 7, Pull-Down, RxActive */
+            P8_35_qep_pin: pinmux_P8_35_qep_pin {
+                pinctrl-single,pins = <0x0D0  0x22>; };     /* Mode 2, Pull-Down, RxActive */
+
 
             /* P8_36 (ZCZ ball U3 ) hdmi    */
            P8_36_default_pin: pinmux_P8_36_default_pin {
@@ -1495,11 +1503,12 @@
            P8_33_pinmux { /* hdmi */
                 compatible = "bone-pinmux-helper";
                 status = "okay";
-                pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
+                pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "qep";
                 pinctrl-0 = <&P8_33_default_pin>;
                 pinctrl-1 = <&P8_33_gpio_pin>;
                 pinctrl-2 = <&P8_33_gpio_pu_pin>;
                 pinctrl-3 = <&P8_33_gpio_pd_pin>;
+                pinctrl-4 = <&P8_33_qep_pin>;
             };
 
            P8_34_pinmux { /* hdmi */
@@ -1516,11 +1525,12 @@
            P8_35_pinmux { /* hdmi */
                 compatible = "bone-pinmux-helper";
                 status = "okay";
-                pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
+                pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "qep";
                 pinctrl-0 = <&P8_35_default_pin>;
                 pinctrl-1 = <&P8_35_gpio_pin>;
                 pinctrl-2 = <&P8_35_gpio_pu_pin>;
                 pinctrl-3 = <&P8_35_gpio_pd_pin>;
+                pinctrl-4 = <&P8_35_qep_pin>;
             };
 
            P8_36_pinmux { /* hdmi */


### PR DESCRIPTION
I had to modify `cape-universala-00A0.dts` to enable pins `P8_33` and `P8_35` for eqep1