### PR TITLE
Add overlays for 400kHz (FAST) i2c on both user buses

### DIFF
--- a/src/arm/BB-I2C1-FAST-00A0.dts
+++ b/src/arm/BB-I2C1-FAST-00A0.dts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2013 CircuitCo
+ *
+ * Virtual cape for I2C1 on connector pins P9.17 P9.18
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/board/am335x-bbw-bbb-base.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+	compatible = "ti,beaglebone", "ti,beaglebone-black", "ti,beaglebone-green";
+
+	// identification
+	part-number = "BB-I2C1";
+	version = "00A0";
+
+	// resources this cape uses
+	exclusive-use =
+		"P9.18",		// i2c1_sda
+		"P9.17",		// i2c1_scl
+
+		"i2c1";		// hardware ip used
+
+
+	fragment@0 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			bb_i2c1_pins: pinmux_bb_i2c1_pins {
+				pinctrl-single,pins = <
+					BONE_P9_18 0x72	// spi0_d1.i2c1_sda, SLEWCTRL_SLOW | INPUT_PULLUP | MODE2
+					BONE_P9_17 0x72	// spi0_cs0.i2c1_scl, SLEWCTRL_SLOW | INPUT_PULLUP | MODE2
+				>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c1>;	// i2c1 is numbered correctly
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&bb_i2c1_pins>;
+
+			// configuration start
+			clock-frequency = <400000>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			// add any i2c devices on the bus here
+
+			// commented out example of a touchscreen (taken from BB-BONE-LCD7-01-00A4)
+			/*
+			maxtouch@4a {
+				compatible = "mXT224";
+				reg = <0x4a>;
+				interrupt-parent = <&gpio4>;
+				interrupts = <19 0x0>;
+				atmel,irq-gpio = <&gpio4 19 0>;
+			};
+			*/
+		};
+	};
+};

--- a/src/arm/BB-I2C2-FAST-00A0.dts
+++ b/src/arm/BB-I2C2-FAST-00A0.dts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2013 CircuitCo
+ *
+ * Virtual cape for I2C2 on connector pins P9.19 P9.20
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "ti,beaglebone", "ti,beaglebone-black", "ti,beaglebone-green";
+
+	/* identification */
+	part-number = "BB-I2C2";
+	version = "00A0";
+
+	/* state the resources this cape uses */
+	exclusive-use =
+		/* the pin header uses */
+		"P9.19",	/* i2c2_sda */
+		"P9.20",	/* i2c2_scl */
+		/* the hardware ip uses */
+		"i2c2";
+
+	fragment@0 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			bb_i2c2_pins: pinmux_bb_i2c2_pins {
+				pinctrl-single,pins = <
+					0x178 0x73	/* i2c2_sda, SLEWCTRL_SLOW | INPUT_PULLUP | MODE3 */
+					0x17c 0x73	/* i2c2_scl, SLEWCTRL_SLOW | INPUT_PULLUP | MODE3 */
+				>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c2>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&bb_i2c2_pins>;
+
+			/* this is the configuration part */
+			clock-frequency = <400000>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			/* add any i2c devices on the bus here */
+
+			// commented out example of a touchscreen (taken from BB-BONE-LCD7-01-00A4) */
+			// maxtouch@4a {
+			//	compatible = "mXT224";
+			//	reg = <0x4a>;
+			//	interrupt-parent = <&gpio4>;
+			//	interrupts = <19 0x0>;
+			//	atmel,irq-gpio = <&gpio4 19 0>;
+			// };
+		};
+	};
+};


### PR DESCRIPTION
The AM335x supports both 100kHz and 400 kHz clock speeds on its i2c buses. This branch adds overlays that allow you to generically enable the i2c buses at the faster clock speed. I've been using this for a while with no problems. I thought this might be useful to have upstream.

These are literally just a copy of the base i2c overlays with `clock-frequency` changed to `<400000>`. If there is a better way to do this, let me know.

Signed-off-by: Jacob Creedon <jcreedon@gmail.com>