### PR TITLE
BB-LCD-ADAFRUIT-18-SPI1: add definition for backlight control

### DIFF
--- a/src/arm/BB-LCD-ADAFRUIT-18-SPI1-00A0.dts
+++ b/src/arm/BB-LCD-ADAFRUIT-18-SPI1-00A0.dts
@@ -22,7 +22,7 @@
  *
  *   P9.12 <--> reset
  *   P9.15 <--> dc
- *   P9.23 <--> lite (gpio)
+ *   P9.23 <--> lite (OPTIONAL)
  *   P9.28 <--> tft_cs
  *   P9.30 <--> mosi
  *   P9.31 <--> clk
@@ -59,6 +59,7 @@
 	fragment@0 {
 		target-path = "/";
 		__overlay__ {
+			/* backlight is optional */
 			backlight_gpio: backlight_gpio {
 				compatible = "gpio-backlight";
 				gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
@@ -76,7 +77,7 @@
 		__overlay__ {
 			P9_12_pinmux { status = "disabled"; };	/* lcd reset */
 			P9_15_pinmux { status = "disabled"; };	/* lcd dc */
-			P9_23_pinmux { status = "disabled"; };	/* lcd gpio backlight */
+			P9_23_pinmux { status = "disabled"; };	/* lcd gpio backlight (OPTIONAL) */
 			P9_28_pinmux { status = "disabled"; };	/* spi1_cs0 */
 			P9_29_pinmux { status = "disabled"; };	/* spi1_d0 */
 			P9_30_pinmux { status = "disabled"; };	/* spi1_d1 */
@@ -117,6 +118,7 @@
 				spi-max-frequency = <16000000>;
 				dc-gpios = <&gpio1 16 0>;      // lcd dc    P9.15 gpio1[16]
 				reset-gpios = <&gpio1 28 0>;   // lcd reset P9.12 gpio1[28]
+				// backlight is optional
 				backlight = <&gpio_backlight>; // lcd lite  P9.23 gpio1[17]
 				// refer to https://elinux.org/Beagleboard:Cape_Expansion_Headers
 				// rotation is optional

--- a/src/arm/BB-LCD-ADAFRUIT-18-SPI1-00A0.dts
+++ b/src/arm/BB-LCD-ADAFRUIT-18-SPI1-00A0.dts
@@ -119,7 +119,7 @@
 				dc-gpios = <&gpio1 16 0>;      // lcd dc    P9.15 gpio1[16]
 				reset-gpios = <&gpio1 28 0>;   // lcd reset P9.12 gpio1[28]
 				// backlight is optional
-				backlight = <&gpio_backlight>; // lcd lite  P9.23 gpio1[17]
+				backlight = <&backlight_gpio>; // lcd lite  P9.23 gpio1[17]
 				// refer to https://elinux.org/Beagleboard:Cape_Expansion_Headers
 				// rotation is optional
 				// rotation = <270>;

--- a/src/arm/BB-LCD-ADAFRUIT-18-SPI1-00A0.dts
+++ b/src/arm/BB-LCD-ADAFRUIT-18-SPI1-00A0.dts
@@ -22,6 +22,7 @@
  *
  *   P9.12 <--> reset
  *   P9.15 <--> dc
+ *   P9.23 <--> lite (gpio)
  *   P9.28 <--> tft_cs
  *   P9.30 <--> mosi
  *   P9.31 <--> clk
@@ -48,29 +49,42 @@
  * https://github.com/notro/tinydrm/issues/1#issuecomment-367279037
  */
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pinctrl/am33xx.h>
 
 /dts-v1/;
 /plugin/;
 
 / {
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			backlight_gpio: backlight_gpio {
+				compatible = "gpio-backlight";
+				gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
+				// connect lcd lite pin to P9.23 which is gpio1[17]
+				// refer to https://elinux.org/Beagleboard:Cape_Expansion_Headers
+			};
+		};
+	};
 
 	/*
 	 * Free up the pins used by the cape from the pinmux helpers.
 	 */
-	fragment@0 {
+	fragment@1 {
 		target = <&ocp>;
 		__overlay__ {
+			P9_12_pinmux { status = "disabled"; };	/* lcd reset */
+			P9_15_pinmux { status = "disabled"; };	/* lcd dc */
+			P9_23_pinmux { status = "disabled"; };	/* lcd gpio backlight */
 			P9_28_pinmux { status = "disabled"; };	/* spi1_cs0 */
 			P9_29_pinmux { status = "disabled"; };	/* spi1_d0 */
 			P9_30_pinmux { status = "disabled"; };	/* spi1_d1 */
 			P9_31_pinmux { status = "disabled"; };	/* spi1_sclk */
-			P9_12_pinmux { status = "disabled"; };	/* reset:60 P9.12 GPIO1_28 */
-			P9_15_pinmux { status = "disabled"; };	/* dc:48    P9.15 GPIO1_16 */
 		};
 	};
 
-	fragment@1 {
+	fragment@2 {
 		target = <&am33xx_pinmux>;
 		__overlay__ {
 			/* default state has all gpios released and mode set to uart1 */
@@ -86,7 +100,7 @@
 		};
 	};
 
-	fragment@2 {
+	fragment@3 {
 		target = <&spi1>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -101,11 +115,12 @@
 				compatible = "jianda,jd-t18003-t01", "sitronix,st7735r";
 				reg = <0>;
 				spi-max-frequency = <16000000>;
-				/* refer to https://elinux.org/Beagleboard:Cape_Expansion_Headers */
-				dc-gpios = <&gpio1 16 0>;    /* dc:48    P9.15 GPIO1_16 */
-				reset-gpios = <&gpio1 28 0>; /* reset:60 P9.12 GPIO1_28 */
-				/* rotation is optional */
-				/* rotation = <270>; */
+				dc-gpios = <&gpio1 16 0>;      // lcd dc    P9.15 gpio1[16]
+				reset-gpios = <&gpio1 28 0>;   // lcd reset P9.12 gpio1[28]
+				backlight = <&gpio_backlight>; // lcd lite  P9.23 gpio1[17]
+				// refer to https://elinux.org/Beagleboard:Cape_Expansion_Headers
+				// rotation is optional
+				// rotation = <270>;
 			};
 
 		};


### PR DESCRIPTION
Add defintion for GPIO backlight control on Adafruit 1.8" TFT LCD.

Connect `lite` pin on lcd to [`P9.23`](https://elinux.org/Beagleboard:Cape_Expansion_Headers)