### PR TITLE
BB-LCD-ADAFRUIT-18-SPI1: add pwm backlight on P9.14

### DIFF
--- a/src/arm/BB-LCD-ADAFRUIT-18-SPI1-00A0.dts
+++ b/src/arm/BB-LCD-ADAFRUIT-18-SPI1-00A0.dts
@@ -21,8 +21,9 @@
  * It should be connected to BeagleBone SPI1 bus:
  *
  *   P9.12 <--> reset
+ *   P9.14 <--> lite (pwm) [OPTIONAL]
  *   P9.15 <--> dc
- *   P9.23 <--> lite (OPTIONAL)
+ *   P9.23 <--> lite (gpio) [OPTIONAL]
  *   P9.28 <--> tft_cs
  *   P9.30 <--> mosi
  *   P9.31 <--> clk
@@ -51,31 +52,21 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pinctrl/am33xx.h>
+#include <dt-bindings/board/am335x-bbw-bbb-base.h>
 
 /dts-v1/;
 /plugin/;
 
 / {
-	fragment@0 {
-		target-path = "/";
-		__overlay__ {
-			/* backlight is optional */
-			backlight_gpio: backlight_gpio {
-				compatible = "gpio-backlight";
-				gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
-				// connect lcd lite pin to P9.23 which is gpio1[17]
-				// refer to https://elinux.org/Beagleboard:Cape_Expansion_Headers
-			};
-		};
-	};
 
 	/*
 	 * Free up the pins used by the cape from the pinmux helpers.
 	 */
-	fragment@1 {
+	fragment@0 {
 		target = <&ocp>;
 		__overlay__ {
 			P9_12_pinmux { status = "disabled"; };	/* lcd reset */
+			P9_14_pinmux { status = "disabled"; };  /* lcd pwm backlight (OPTIONAL) */
 			P9_15_pinmux { status = "disabled"; };	/* lcd dc */
 			P9_23_pinmux { status = "disabled"; };	/* lcd gpio backlight (OPTIONAL) */
 			P9_28_pinmux { status = "disabled"; };	/* spi1_cs0 */
@@ -85,7 +76,7 @@
 		};
 	};
 
-	fragment@2 {
+	fragment@1 {
 		target = <&am33xx_pinmux>;
 		__overlay__ {
 			/* default state has all gpios released and mode set to uart1 */
@@ -98,10 +89,79 @@
 					// 0x164 0x12	/* eCAP0_in_PWM0_out.spi1_cs1 OUTPUT_PULLUP | MODE2 */
 				>;
 			};
+
+			backlight_pwm_pins: pinmux_backlight_pwm_pins {
+				pinctrl-single,pins = <
+					BONE_P9_14 0x06 /* gpmc_a2.ehrpwm1a, OMAP_MUX_MODE6 | AM33XX_PIN_OUTPUT */
+				>;
+			};  /* gpmc_a2.ehrpwm1a */
+		};
+	};
+
+	fragment@2 {
+		target = <&epwmss1>;
+		__overlay__ {
+			status = "okay";
 		};
 	};
 
 	fragment@3 {
+		target = <&ehrpwm1>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&backlight_pwm_pins>;
+			status = "okay";
+		};
+	};
+
+	fragment@4 {
+		target-path = "/";
+		__overlay__ {
+
+			bl_reg: backlight-regulator {
+				compatible = "regulator-fixed";
+				regulator-name = "backlight";
+				regulator-always-on;
+				regulator-boot-on;
+			};
+
+			/* backlight is optional */
+			backlight_gpio: backlight_gpio {
+				compatible = "gpio-backlight";
+				gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
+				// connect lcd lite pin to P9.23 which is gpio1[17]
+				// refer to https://elinux.org/Beagleboard:Cape_Expansion_Headers
+			};
+
+			/*
+			 * Turn the PWM backlight on by setting bl_power to 0:
+			 * echo 0 > /sys/devices/platform/backlight_pwm/backlight/backlight_pwm/bl_power
+			 */
+			backlight_pwm: backlight_pwm {
+				// P9.14 <--> lite (pwm-backlight EHRPWM1A)
+				status = "okay";
+				compatible = "pwm-backlight";
+				pwms = <&ehrpwm1 0 500000 0>;
+				brightness-levels = <
+					0  1  2  3  4  5  6  7  8  9
+					10 11 12 13 14 15 16 17 18 19
+					20 21 22 23 24 25 26 27 28 29
+					30 31 32 33 34 35 36 37 38 39
+					40 41 42 43 44 45 46 47 48 49
+					50 51 52 53 54 55 56 57 58 59
+					60 61 62 63 64 65 66 67 68 69
+					70 71 72 73 74 75 76 77 78 79
+					80 81 82 83 84 85 86 87 88 89
+					90 91 92 93 94 95 96 97 98 99
+					100
+				>;
+				default-brightness-level = <100>;
+				power-supply = <&bl_reg>;
+			};
+		};
+	};
+
+	fragment@5 {
 		target = <&spi1>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -119,12 +179,13 @@
 				dc-gpios = <&gpio1 16 0>;      // lcd dc    P9.15 gpio1[16]
 				reset-gpios = <&gpio1 28 0>;   // lcd reset P9.12 gpio1[28]
 				// backlight is optional
-				backlight = <&backlight_gpio>; // lcd lite  P9.23 gpio1[17]
+				// choose either pwm or gpio control
+				//backlight = <&backlight_gpio>; // lcd lite  P9.23 gpio1[17]
+				backlight = <&backlight_pwm>;    // lcd lite  P9.14 gpmc_a2.ehrpwm1a
 				// refer to https://elinux.org/Beagleboard:Cape_Expansion_Headers
 				// rotation is optional
 				// rotation = <270>;
 			};
-
 		};
 	};
 };


### PR DESCRIPTION
Add definition for PWM backlight control on Adafruit 1.8" TFT LCD.

**Instructions:**
* Connect lite pin on lcd to P9.14.
* Turn on backlight on by setting `bl_power` to `0` _(`FB_BLANK_UNBLACK`)_ per [comment](https://github.com/beagleboard/bb.org-overlays/pull/68#issuecomment-371281619) by @notro in PR #68:
```
echo 0 > /sys/devices/platform/backlight_pwm/backlight/backlight_pwm/bl_power
```
NOTE: `FB_BLANK_UNBLACK` is specified in [sysfs-class-backlight](https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-backlight)
