### PR TITLE
Add : additional overlays to support Yantrr INDU-RS capes

### DIFF
--- a/src/arm/BB-UART1-RTSCTS-00A0.dts
+++ b/src/arm/BB-UART1-RTSCTS-00A0.dts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018
+ * Yantrr Electronic Systems Pvt. Ltd. - http://www.yantrr.com/
+ *
+ * BeagleBone cape RS485 / RS422 using UART1-RTSCTS connector pins P9.19 P9.20
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or 
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+*/
+
+/dts-v1/;
+/plugin/;
+
+/{
+  compatible = "ti,beaglebone", "ti,beaglebone-black";
+
+  part-number = "BB-UART1-RTSCTS";
+  version = "00A0";
+
+  exclusive-use =
+    "P9.19",    // uart1_rtsn     conflict with I2C2_SCL  i.e. cape EEPROM
+    "P9.20";    // uart1_ctsn     conflict with I2C2_SDA  i.e. cape EEPROM
+
+  fragment@0 {
+    /* Sets pinmux for flow control pins. */
+    target = <&am33xx_pinmux>;
+    __overlay__ {
+      u1_rtscts_pins: pinmux_u1_rtscts_pins {
+        pinctrl-single,pins = <
+          0x17c 0x08      /* mode 0 (uart1_rtsn) */
+          0x178 0x30      /* mode 0 (uart1_ctsn) */
+        >;
+      };
+    };
+  };
+
+  fragment@1 {
+    /* Enable pinmux-helper driver for setting mux configuration. */
+    target = <&ocp>; /* On-Chip Peripherals */
+    __overlay__ {
+      uart1-rtscts-pinmux {
+        compatible = "bone-pinmux-helper"; /* Use the pinmux helper */
+        status="okay";
+        /* Define custom names for indexes in pinctrl array: */
+        pinctrl-names = "default";
+        /* Set the elements of the pinctrl array to the pinmux overlays
+           defined above: */
+        pinctrl-0 = <&u1_rtscts_pins>;
+      };
+    };
+  };
+};

--- a/src/arm/BB-UART4-RTSCTS-00A0.dts
+++ b/src/arm/BB-UART4-RTSCTS-00A0.dts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018
+ * Yantrr Electronic Systems Pvt. Ltd. - http://www.yantrr.com/
+ *
+ * BeagleBone cape RS485 / RS422 using UART4-RTSCTS connector pins P8.33 P8.35
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or 
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+*/
+
+/dts-v1/;
+/plugin/;
+
+/{
+  compatible = "ti,beaglebone", "ti,beaglebone-black";
+
+  part-number = "BB-UART4-RTSCTS";
+  version = "00A0";
+
+  exclusive-use =
+    "P8.33",    // uart4_rtsn     conflict with HDMI pin
+    "P8.35";    // uart4_ctsn     conflict with HDMI pin
+
+  fragment@0 {
+    /* Sets pinmux for flow control pins. */
+    target = <&am33xx_pinmux>;
+    __overlay__ {
+      u4_rtscts_pins: pinmux_u4_rtscts_pins {
+        pinctrl-single,pins = <
+          0x0d4 0x0e      /* mode 6 (uart4_rtsn) */
+          0x0d0 0x36      /* mode 6 (uart4_ctsn) */
+        >;
+      };
+    };
+  };
+
+  fragment@1 {
+    /* Enable pinmux-helper driver for setting mux configuration. */
+    target = <&ocp>; /* On-Chip Peripherals */
+    __overlay__ {
+      uart4-rtscts-pinmux {
+        compatible = "bone-pinmux-helper"; /* Use the pinmux helper */
+        status="okay";
+        /* Define custom names for indexes in pinctrl array: */
+        pinctrl-names = "default";
+        /* Set the elements of the pinctrl array to the pinmux overlays
+           defined above: */
+        pinctrl-0 = <&u4_rtscts_pins>;
+      };
+    };
+  };
+};

--- a/src/arm/BB-UART5-RTSCTS-00A0.dts
+++ b/src/arm/BB-UART5-RTSCTS-00A0.dts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018
+ * Yantrr Electronic Systems Pvt. Ltd. - http://www.yantrr.com/
+ *
+ * BeagleBone cape RS485 / RS422 using UART5-RTSCTS connector pins P8.32 P8.31
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or 
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+*/
+
+/dts-v1/;
+/plugin/;
+
+/{
+  compatible = "ti,beaglebone", "ti,beaglebone-black";
+
+  part-number = "BB-UART5-RTSCTS";
+  version = "00A0";
+
+  exclusive-use =
+    "P8.32",    // uart5_rtsn     conflict with HDMI pin
+    "P8.31";    // uart5_ctsn     conflict with HDMI pin
+
+  fragment@0 {
+    /* Sets pinmux for flow control pins. */
+    target = <&am33xx_pinmux>;
+    __overlay__ {
+      u5_rtscts_pins: pinmux_u5_rtscts_pins {
+        pinctrl-single,pins = <
+          0x0dc 0x0e      /* mode 6 (uart5_rtsn) */
+          0x0d8 0x36      /* mode 6 (uart5_ctsn) */
+        >;
+      };
+    };
+  };
+
+  fragment@1 {
+    /* Enable pinmux-helper driver for setting mux configuration. */
+    target = <&ocp>; /* On-Chip Peripherals */
+    __overlay__ {
+      uart5-rtscts-pinmux {
+        compatible = "bone-pinmux-helper"; /* Use the pinmux helper */
+        status="okay";
+        /* Define custom names for indexes in pinctrl array: */
+        pinctrl-names = "default";
+        /* Set the elements of the pinctrl array to the pinmux overlays
+           defined above: */
+        pinctrl-0 = <&u5_rtscts_pins>;
+      };
+    };
+  };
+};


### PR DESCRIPTION
Details of Yantrr INDU-RS capes with and without DC-DC converter : 
- http://yantrr.com/products/industrial-capes
- https://www.yantrr.com/wiki/INDU-RS#Overview

Utilizing Modbus protocol, these capes can be used to transform Yantrr's VIBE/VIBEQ/VIBE2 IoT platform into powerful SCADA & process control systems. INDU-RS capes are fully compatible with BeagleBone CPU platform. 