### PR TITLE
Finished off the Bela overlay

### DIFF
--- a/src/arm/BB-BELA-B2.dts
+++ b/src/arm/BB-BELA-B2.dts
@@ -116,6 +116,8 @@
 			P1_35_bela: pinmux_default_bela13 { pinctrl-single,pins = <0xe8 0x27>; };
 			P1_32_bela: pinmux_default_bela14 { pinctrl-single,pins = <0x170 0x27>; };
 			P1_30_bela: pinmux_default_bela15 { pinctrl-single,pins = <0x174 0x27>; };
+			P1_02_bela: pinmux_default_led0 { pinctrl-single,pins = <0xe4 0x27>; };
+			P1_04_bela: pinmux_default_led1 { pinctrl-single,pins = <0xec 0x27>; };
 
 			/* Pinmux for i2c on Bela header */
 			i2c1_pins: pinmux_i2c1_pins {
@@ -244,6 +246,8 @@
 			P1_35_pinmux{ pinctrl-0 = <&P1_35_bela>; };
 			P1_32_pinmux{ pinctrl-0 = <&P1_32_bela>; };
 			P1_30_pinmux{ pinctrl-0 = <&P1_30_bela>; };
+			P1_02_pinmux{ pinctrl-0 = <&P1_02_bela>; };
+			P1_04_pinmux{ pinctrl-0 = <&P1_04_bela>; };
 		};
 	};
 

--- a/src/arm/BB-BELA-B2.dts
+++ b/src/arm/BB-BELA-B2.dts
@@ -100,9 +100,22 @@
 				>;
 			};
 
-			P2_01_bela: pinmux_default_bela {
-				pinctrl-single,pins = <0x48 0x27>;
-			};
+			P2_01_bela: pinmux_default_bela0 { pinctrl-single,pins = <0x48 0x27>; };
+			P2_02_bela: pinmux_default_bela1 { pinctrl-single,pins = <0x6c 0x27>; };
+			P2_04_bela: pinmux_default_bela2 { pinctrl-single,pins = <0x68 0x27>; };
+			P2_06_bela: pinmux_default_bela3 { pinctrl-single,pins = <0x64 0x27>; };
+			P2_08_bela: pinmux_default_bela4 { pinctrl-single,pins = <0x78 0x27>; };
+			P2_10_bela: pinmux_default_bela5 { pinctrl-single,pins = <0x50 0x27>; };
+			P2_18_bela: pinmux_default_bela6 { pinctrl-single,pins = <0x3c 0x27>; };
+			P2_20_bela: pinmux_default_bela7 { pinctrl-single,pins = <0x88 0x27>; };
+			P2_22_bela: pinmux_default_bela8 { pinctrl-single,pins = <0x38 0x27>; };
+			P2_24_bela: pinmux_default_bela9 { pinctrl-single,pins = <0x30 0x27>; };
+			P2_25_bela: pinmux_default_bela10 { pinctrl-single,pins = <0x16c 0x27>; };
+			P2_27_bela: pinmux_default_bela11 { pinctrl-single,pins = <0x168 0x27>; };
+			P2_35_bela: pinmux_default_bela12 { pinctrl-single,pins = <0xe0 0x27>; };
+			P1_35_bela: pinmux_default_bela13 { pinctrl-single,pins = <0xe8 0x27>; };
+			P1_32_bela: pinmux_default_bela14 { pinctrl-single,pins = <0x170 0x27>; };
+			P1_30_bela: pinmux_default_bela15 { pinctrl-single,pins = <0x174 0x27>; };
 
 			/* Pinmux for i2c on Bela header */
 			i2c1_pins: pinmux_i2c1_pins {
@@ -215,9 +228,22 @@
 	fragment@7 {
 		target = <&ocp>;
 		__overlay__ {
-			P2_01_pinmux{
-				pinctrl-0 = <&P2_01_bela>;
-			};
+			P2_01_pinmux{ pinctrl-0 = <&P2_01_bela>; };
+			P2_02_pinmux{ pinctrl-0 = <&P2_02_bela>; };
+			P2_04_pinmux{ pinctrl-0 = <&P2_04_bela>; };
+			P2_06_pinmux{ pinctrl-0 = <&P2_06_bela>; };
+			P2_08_pinmux{ pinctrl-0 = <&P2_08_bela>; };
+			P2_10_pinmux{ pinctrl-0 = <&P2_10_bela>; };
+			P2_18_pinmux{ pinctrl-0 = <&P2_18_bela>; };
+			P2_20_pinmux{ pinctrl-0 = <&P2_20_bela>; };
+			P2_22_pinmux{ pinctrl-0 = <&P2_22_bela>; };
+			P2_24_pinmux{ pinctrl-0 = <&P2_24_bela>; };
+			P2_25_pinmux{ pinctrl-0 = <&P2_25_bela>; };
+			P2_27_pinmux{ pinctrl-0 = <&P2_27_bela>; };
+			P2_35_pinmux{ pinctrl-0 = <&P2_35_bela>; };
+			P1_35_pinmux{ pinctrl-0 = <&P1_35_bela>; };
+			P1_32_pinmux{ pinctrl-0 = <&P1_32_bela>; };
+			P1_30_pinmux{ pinctrl-0 = <&P1_30_bela>; };
 		};
 	};
 

--- a/src/arm/BB-BELA-B2.dts
+++ b/src/arm/BB-BELA-B2.dts
@@ -19,13 +19,32 @@
 	fragment@0 {
 		target = <&ocp>;
 		__overlay__ {
+			P2_09_pinmux { status = "disabled"; }; 
+			P2_11_pinmux { status = "disabled"; }; 
+			P2_26_pinmux { status = "disabled"; };
+			P2_30_pinmux { status = "disabled"; };
+			P2_32_pinmux { status = "disabled"; };
+			P2_33_pinmux { status = "disabled"; };
+			P2_34_pinmux { status = "disabled"; };
+			P1_05_pinmux { status = "disabled"; };
+			P1_06_pinmux { status = "disabled"; };
+			P1_08_pinmux { status = "disabled"; };
+			P1_09_pinmux { status = "disabled"; };
+			P1_10_pinmux { status = "disabled"; };
+			P1_11_pinmux { status = "disabled"; };
+			P1_12_pinmux { status = "disabled"; };
+			P1_26_pinmux { status = "disabled"; };
+			P1_28_pinmux { status = "disabled"; };
+			P1_29_pinmux { status = "disabled"; };
+			P1_33_pinmux { status = "disabled"; };
+			P1_36_pinmux { status = "disabled"; };
 			P9_25_pinmux { status = "disabled"; }; /* mcasp0_ahclkx */
 			P9_28_pinmux { status = "disabled"; }; /* mcasp0_axr2 */
 			P9_29_pinmux { status = "disabled"; }; /* mcasp0_fsx */
 			P9_31_pinmux { status = "disabled"; }; /* mcasp0_ahclk */
 			P9_30_pinmux { status = "disabled"; }; /* mcasp0_axr0 */
 
-			P9_22_pinmux { status = "disabled"; }; /* spi0_sclk * /
+			P9_22_pinmux { status = "disabled"; }; /* spi0_sclk */
 			P9_21_pinmux { status = "disabled"; }; /* spi0_d0 */
 			P9_18_pinmux { status = "disabled"; }; /* spi0_d1 */
 			P9_17_pinmux { status = "disabled"; }; /* spi0_cs0 */
@@ -33,6 +52,15 @@
 	};
 
 	fragment@1 {
+		target = <&i2c0>;
+		__overlay__ {
+			tda19988 {
+				status = "disabled";
+			};
+		};
+	};
+
+	fragment@2 {
 		target = <&am33xx_pinmux>;
 		__overlay__ {
 			/* Pinmux for McASP0 (audio i/o) */
@@ -52,7 +80,7 @@
 					0x150 0x30 /* spi0_sclk, 			P9_22 | MODE0 | INPUT_PULLUP */
 					0x154 0x30 /* spi0_d0, 				P9_21 | MODE0 | INPUT_PULLUP */
 					0x158 0x10 /* spi0_d1, 				P9_18 | MODE0 | OUTPUT_PULLUP */
-					0x15c 0x10 /* spi0_cs0, 			P9_17 | MODE0 | OUTPUT_PULLUP */
+					0x15c 0x27 /* spi0_cs0, 			P9_17 | MODE0 | OUTPUT_PULLUP */
 				>;
 			};
 
@@ -69,6 +97,24 @@
 					// if there is no driver associated with it
 					/* Is needed for pin multiplexing Bela button correctly */
 					0x1a4 0x37 /* gpio3[19], 			P9_27 | MODE7 | INPUT_PULLUP */
+				>;
+			};
+
+			P2_01_bela: pinmux_default_bela {
+				pinctrl-single,pins = <0x48 0x27>;
+			};
+
+			/* Pinmux for i2c on Bela header */
+			i2c1_pins: pinmux_i2c1_pins {
+				pinctrl-single,pins = <
+					0x180 0x33 /* i2c1_sda, 	P9_26 | MODE3 | INPUT_PULLUP */
+					0x184 0x33 /* i2c1_scl,		P9_24 | MODE3 | INPUT_PULLUP */
+				>;
+			};
+
+			/* pinmux for BB digitals */
+			bb_digitals: pinmux_bb_digitals {
+				pinctrl-single,pins = <
 					/* Pinmux for GPIO (digital i/o) */
 					0x090 0x27 /* gpio2[2], 			P8_07 | MODE7 | INPUT_PULLDOWN */
 					0x094 0x27 /* gpio2[3], 			P8_08 | MODE7 | INPUT_PULLDOWN */
@@ -87,19 +133,11 @@
 					0x0e4 0x27 /* gpio2[23],			P8_29 | MODE7 | INPUT_PULLDOWN */
 					0x0ec 0x27 /* gpio2[25],			P8_30 | MODE7 | INPUT_PULLDOWN */
 				>;
-			};
-
-			/* Pinmux for i2c on Bela header */
-			i2c1_pins: pinmux_i2c1_pins {
-				pinctrl-single,pins = <
-					0x180 0x33 /* i2c1_sda, 	P9_26 | MODE3 | INPUT_PULLUP */
-					0x184 0x33 /* i2c1_scl,		P9_24 | MODE3 | INPUT_PULLUP */
-				>;
-			};
+			};	
 		};
 	};
 
-	fragment@2 {
+	fragment@3 {
 		target = <&i2c1>;
 		__overlay__ {
 			pinctrl-names = "default";
@@ -111,7 +149,7 @@
 	};
 
 	/* McASP config */
-	fragment@3 {
+	fragment@4 {
 		target = <&mcasp0>;
 		__overlay__ {
 			pinctrl-names = "default";
@@ -135,7 +173,7 @@
 	};
 
 	/* PRU config */
-	fragment@4 {
+	fragment@5 {
 		target-path="/";
 		__overlay__ {
 			ocp {
@@ -164,7 +202,7 @@
 		};
 	};
 
-	fragment@5 {
+	fragment@6 {
 		target = <&spi0>;
 		__overlay__ {
 			pinctrl-names = "default";
@@ -173,4 +211,26 @@
 			status = "okay";
 		};
 	};
+
+	fragment@7 {
+		target = <&ocp>;
+		__overlay__ {
+			P2_01_pinmux{
+				pinctrl-0 = <&P2_01_bela>;
+			};
+		};
+	};
+
+	fragment@8 {
+		target-path="/";
+		__overlay__ {
+			bela_digitals {
+				compatible = "gpio-leds";
+				pinctrl-0 = <&bb_digitals>;
+				pinctrl-1 = <&bb_digitals>;
+				pinctrl-names = "default", "sleep";
+			};
+		};
+	};
+			
 };


### PR DESCRIPTION
The `BB-BELA-B2.dts` overlay will now work on both BBx and PB devices.

We use different pins for our GPIOs on the two boards. These are handled as follows:
On the PB:
- `fragment@0` disables the "universal" pins
- `fragment@7` re-enables them with a different default value
- `fragment@8`fails to apply
- `config-pin` can be used to manually change the function of those pins.
- we now support uboot overlays as well.

On the BBx:
- `fragment@0` fails to apply (the `Px_xx_pinmumx` do not exist)
- `fragment@7` fails to apply
- `fragment@8` applies successfully 
- more overlays can be added with `capemgr` or uboot overlays
