### PR TITLE
config-pin bug, efficiency improvement

### DIFF
--- a/tools/beaglebone-universal-io/config-pin
+++ b/tools/beaglebone-universal-io/config-pin
@@ -5,7 +5,7 @@ GPIODIR=/sys/class/gpio
 BOARD="original"
 
 disable_capemgr_load=$(grep -c bone_capemgr.uboot_capemgr_enabled=1 /proc/cmdline)
-machine=$(cat /proc/device-tree/model | sed "s/ /_/g" | tr -d '\000')
+machine=$(sed "s/ /_/g;s/\o0//g" /proc/device-tree/model)
 case "${machine}" in
 TI_AM335x_BeagleBone_Blue)
 	#overlays built-in, no slots file...

--- a/tools/beaglebone-universal-io/config-pin
+++ b/tools/beaglebone-universal-io/config-pin
@@ -1412,7 +1412,7 @@ config_pin () {
 			;;
 
 		# GPIO with pull-down enabled
-		[iI][nN]-|[iI][nN][pP][uU][tT]-|[iI][nN][-_][pP][dD]|[iI][nN][pP][dD][tT][-_][pP][dD])
+		[iI][nN]-|[iI][nN][pP][uU][tT]-|[iI][nN][-_][pP][dD]|[iI][nN][pP][uU][tT][-_][pP][dD])
 			MODE=gpio_pd;
 			DIR=in
 			;;


### PR DESCRIPTION
1. Presently, config-pin accepts "inp**d**t_pd" but not "inp**u**t_pd".
2. The three commands used to read and process /proc/device-tree/model into "machine" can be condensed into a single call to sed. This should save a little execution time.