### PR TITLE
Update PB-MCP2515-SPI1.dts

### DIFF
--- a/src/arm/PB-MCP2515-SPI1.dts
+++ b/src/arm/PB-MCP2515-SPI1.dts
@@ -74,7 +74,7 @@
         __overlay__ {
             #address-cells = <1>;
             #size-cells = <0>;
-            can0: mcp2515@0 {
+            can0: mcp2515@1 {
                 status = "okay";
                 /* use Chip Select 1. P2.31 pin is labelled
                    "SPI1 CS" on PB silk and is spi1_cs1 */


### PR DESCRIPTION
Prevent warning by matching the entry for reg 1:
src/arm/PB-MCP2515-SPI1.dts:77.29-94.15: Warning (spi_bus_reg): /fragment@4/__overlay__/mcp2515@0: SPI bus unit address format error, expected "1" (edited) 