### PR TITLE
pru shared memory example 1 (one device, multiple memories)

### DIFF
--- a/src/arm/AM335X-PRU-RPROC-4-14-TI-00A0.dts
+++ b/src/arm/AM335X-PRU-RPROC-4-14-TI-00A0.dts
@@ -47,6 +47,17 @@
 					ranges = <0x0 0x4a300000 0x80000>;
 					status = "okay";
 
+					shmem@0 {
+						reg = <0x0 0x2000>,
+						      <0x2000 0x2000>,
+						      <0x10000 0x3000>;
+						reg-names = "dram0",
+							    "dram1",
+							    "dram2";
+						compatible = "uio";
+						symlink = "uio/pru-shmem";
+					};
+
 					pruss: pruss@0 {
 						compatible = "ti,am3356-pruss";
 						reg = <0x0 0x80000>;

--- a/src/arm/AM335X-PRU-RPROC-4-19-TI-00A0.dts
+++ b/src/arm/AM335X-PRU-RPROC-4-19-TI-00A0.dts
@@ -47,6 +47,17 @@
 					ranges;
 					status = "okay";
 
+					shmem@4a300000 {
+						reg = <0x4a300000 0x2000>,
+						      <0x4a302000 0x2000>,
+						      <0x4a310000 0x3000>;
+						reg-names = "dram0",
+							    "dram1",
+							    "dram2";
+						compatible = "uio";
+						symlink = "uio/pru-shmem";
+					};
+
 					pruss: pruss@4a300000 {
 						compatible = "ti,am3356-pruss";
 						reg = <0x4a300000 0x80000>;

--- a/src/arm/AM335X-PRU-RPROC-4-4-TI-00A0.dts
+++ b/src/arm/AM335X-PRU-RPROC-4-4-TI-00A0.dts
@@ -54,6 +54,17 @@
 					#size-cells = <1>;
 					ranges;
 
+					shmem@4a300000 {
+						reg = <0x4a300000 0x2000>,
+						      <0x4a302000 0x2000>,
+						      <0x4a310000 0x3000>;
+						reg-names = "dram0",
+							    "dram1",
+							    "dram2";
+						compatible = "uio";
+						symlink = "uio/pru-shmem";
+					};
+
 					pruss_intc: intc@4a320000 {
 						compatible = "ti,am3352-pruss-intc";
 						reg = <0x4a320000 0x2000>;

--- a/src/arm/AM335X-PRU-RPROC-4-9-TI-00A0.dts
+++ b/src/arm/AM335X-PRU-RPROC-4-9-TI-00A0.dts
@@ -47,6 +47,17 @@
 					ranges;
 					status = "okay";
 
+					shmem@4a300000 {
+						reg = <0x4a300000 0x2000>,
+						      <0x4a302000 0x2000>,
+						      <0x4a310000 0x3000>;
+						reg-names = "dram0",
+							    "dram1",
+							    "dram2";
+						compatible = "uio";
+						symlink = "uio/pru-shmem";
+					};
+
 					pruss: pruss@4a300000 {
 						compatible = "ti,am3356-pruss";
 						reg = <0x4a300000 0x2000>,


### PR DESCRIPTION
Note that https://github.com/mvduin/py-uio/blob/master/etc/modprobe.d/uio.conf is required to make this work.