### PR TITLE
Fixes for BB-GATEWAY-WL1837-00A0.dts and BB-BONE-WL1837-00A0.dts

### DIFF
--- a/src/arm/BB-BONE-WL1837-00A0.dts
+++ b/src/arm/BB-BONE-WL1837-00A0.dts
@@ -268,13 +268,13 @@
 		__overlay__ {
 			emmc_rst {
 				gpio-hog;
-				gpio = <20 0>;
+				gpios = <20 0>;
 				output-low;
 				line-name = "emmc_resetN";
 			};
 			eeprom_en {
 				gpio-hog;
-				gpio = <16 0>;
+				gpios = <16 0>;
 				output-high;
 				line-name = "eeprom_enable";
 			};

--- a/src/arm/BB-BONE-WL1837-00A0.dts
+++ b/src/arm/BB-BONE-WL1837-00A0.dts
@@ -79,8 +79,8 @@
 			P8_05_pinmux { status = "disabled"; };	/* P8_05: gpmc_ad2.mmc1_dat2 */
 			P8_06_pinmux { status = "disabled"; };	/* P8_06: gpmc_ad3.mmc1_dat3 */
 
-			P8_22_pinmux { status = "disabled"; };	/* P8_22: gpio0_2 WL_EN */
-			P8_42_pinmux { status = "disabled"; };	/* P8_42: gpio0_7 WL_IRQ */
+			P9_22_pinmux { status = "disabled"; };	/* P9_22: gpio0_2 WL_EN */
+			P9_42_pinmux { status = "disabled"; };	/* P9_42: gpio0_7 WL_IRQ */
 			P8_26_pinmux { status = "disabled"; };	/* P8_26: gpmc_csn0.gpio1_29 BF_EN*/
 			P8_07_pinmux { status = "disabled"; };	/* P8_07: gpmc_advn_ale.gpio2_2  Audio_sync*/
 			P9_15_pinmux { status = "disabled"; };	/* P9_15: EEPROM Enable */
@@ -135,8 +135,8 @@
 			/* wl18xx card enable/irq GPIOs. */
 			bb_wlan_pins: pinmux_bb_wlan_pins {
 				pinctrl-single,pins = <
-					BONE_P9_22  (PIN_OUTPUT_PULLUP | MUX_MODE7)	/* P8_22: gpio0_2 WL_EN */
-					BONE_P9_42A (PIN_INPUT_PULLUP | MUX_MODE7)	/* P8_42: gpio0_7 WL_IRQ */
+					BONE_P9_22  (PIN_OUTPUT_PULLUP | MUX_MODE7)	/* P9_22: gpio0_2 WL_EN */
+					BONE_P9_42A (PIN_INPUT_PULLUP | MUX_MODE7)	/* P9_42: gpio0_7 WL_IRQ */
 					BONE_P8_26  (PIN_OUTPUT_PULLUP | MUX_MODE0)	/* P8_26: gpmc_csn0.gpio1_29 BF_EN*/
 					BONE_P8_07  (PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* P8_07: gpmc_advn_ale.gpio2_2  Audio_sync*/
 					BONE_P9_15  (PIN_OUTPUT_PULLUP | MUX_MODE7)	/* P9_15: EEPROM Enable */
@@ -146,8 +146,8 @@
 			/* wl18xx card enable/irq GPIOs. */
 			bb_wlan_pins_sleep: pinmux_bb_wlan_pins_sleep {
 				pinctrl-single,pins = <
-					BONE_P9_22  (PIN_OUTPUT_PULLUP | MUX_MODE7)	/* P8_22: gpio0_2 WL_EN */
-					BONE_P9_42A (PIN_INPUT_PULLUP | MUX_MODE7)	/* P8_42: gpio0_7 WL_IRQ */
+					BONE_P9_22  (PIN_OUTPUT_PULLUP | MUX_MODE7)	/* P9_22: gpio0_2 WL_EN */
+					BONE_P9_42A (PIN_INPUT_PULLUP | MUX_MODE7)	/* P9_42: gpio0_7 WL_IRQ */
 					BONE_P8_26  (PIN_OUTPUT_PULLUP | MUX_MODE0)	/* P8_26: gpmc_csn0.gpio1_29 BF_EN*/
 					BONE_P8_07  (PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* P8_07: gpmc_advn_ale.gpio2_2  Audio_sync*/
 					BONE_P9_15  (PIN_OUTPUT_PULLUP | MUX_MODE7)	/* P9_15: EEPROM Enable */

--- a/src/arm/BB-GATEWAY-WL1837-00A0.dts
+++ b/src/arm/BB-GATEWAY-WL1837-00A0.dts
@@ -265,13 +265,13 @@
 		__overlay__ {
 			eeprom_disable {
 				gpio-hog;
-				gpio = <16 GPIO_ACTIVE_LOW>;
+				gpios = <16 GPIO_ACTIVE_LOW>;
 				output-low;
 				line-name = "eeprom_disable";
 			};
 			emmc_rst {
 				gpio-hog;
-				gpio = <20 GPIO_ACTIVE_LOW>;
+				gpios = <20 GPIO_ACTIVE_LOW>;
 				output-low;
 				line-name = "emmc_resetN";
 			};

--- a/src/arm/BB-GATEWAY-WL1837-00A0.dts
+++ b/src/arm/BB-GATEWAY-WL1837-00A0.dts
@@ -82,7 +82,7 @@
 			P8_05_pinmux { status = "disabled"; };	/* P8_05: gpmc_ad2.mmc1_dat2 */
 			P8_06_pinmux { status = "disabled"; };	/* P8_06: gpmc_ad3.mmc1_dat3 */
 
-			P8_22_pinmux { status = "disabled"; };	/* P8_22: gpio0_2 WL_EN */
+			P9_22_pinmux { status = "disabled"; };	/* P9_22: gpio0_2 WL_EN */
 			P9_42_pinmux { status = "disabled"; };	/* P9_42: gpio0_7 WL_IRQ */
 			P8_07_pinmux { status = "disabled"; };	/* P8_07: gpmc_advn_ale.gpio2_2 Audio_sync */
 
@@ -176,7 +176,7 @@
 			/* wl18xx card enable/irq GPIOs. */
 			wlan_pins: pinmux_wlan_pins {
 				pinctrl-single,pins = <
-					AM33XX_IOPAD(0x814, PIN_OUTPUT_PULLUP | MUX_MODE7)	/* P8_22: gpio0_2 WL_EN */
+					AM33XX_IOPAD(0x950, PIN_OUTPUT_PULLUP | MUX_MODE7)	/* P9_22: gpio0_2 WL_EN */
 					AM33XX_IOPAD(0x964, PIN_INPUT_PULLUP | MUX_MODE7)	/* P9_42: gpio0_7 WL_IRQ */
 					AM33XX_IOPAD(0x890, PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* P8_07: gpmc_advn_ale.gpio2_2 Audio_sync */
 				>;
@@ -185,7 +185,7 @@
 			/* wl18xx card enable/irq GPIOs. */
 			wlan_pins_sleep: pinmux_wlan_pins_sleep {
 				pinctrl-single,pins = <
-					AM33XX_IOPAD(0x814, PIN_OUTPUT_PULLUP | MUX_MODE7)	/* P8_22: gpio0_2 WL_EN */
+					AM33XX_IOPAD(0x950, PIN_OUTPUT_PULLUP | MUX_MODE7)	/* P9_22: gpio0_2 WL_EN */
 					AM33XX_IOPAD(0x964, PIN_INPUT_PULLUP | MUX_MODE7)	/* P9_42: gpio0_7 WL_IRQ */
 					AM33XX_IOPAD(0x890, PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* P8_07: gpmc_advn_ale.gpio2_2 Audio_sync */
 				>;


### PR DESCRIPTION
WL_EN is on P9_22 and WL_IRQ is on P9_42, as stated in [element14 pinout](https://www.element14.com/community/servlet/JiveServlet/showImage/105-89801-307334/CapeExpansionHeadersP9wGatewayFunctions.jpg).

Wrong GPIO hog definition for some pins, i.e., it should be `gpios` instead of `gpio`.