### PR TITLE
add BBAI LDC4 cape overlay

### DIFF
--- a/src/arm/BBAI_BB-BONE-LCD4-01-00A1.dts
+++ b/src/arm/BBAI_BB-BONE-LCD4-01-00A1.dts
@@ -1,0 +1,343 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/dra.h>
+
+&{/chosen} {
+    overlays{
+        BBAI_BB-BONE-LCD4-01-00A1 = __TIMESTAMP__;
+    };
+};
+
+&dra7_pmx_core {
+    cape_pins_default: cape_pins_default {
+        pinctrl-single,pins = <
+            DRA7XX_CORE_IOPAD(0x379C, MUX_MODE14) /* AB8: P8.3: mmc3_dat6.off */
+            DRA7XX_CORE_IOPAD(0x37A0, MUX_MODE14) /* AB5: P8.4: mmc3_dat7.off */
+            DRA7XX_CORE_IOPAD(0x378C, MUX_MODE14) /* AC9: P8.5: mmc3_dat2.off */
+            DRA7XX_CORE_IOPAD(0x3790, MUX_MODE14) /* AC3: P8.6: mmc3_dat3.off */
+            DRA7XX_CORE_IOPAD(0x36EC, MUX_MODE14) /* G14: P8.7: mcasp1_axr14.off */
+            DRA7XX_CORE_IOPAD(0x36F0, MUX_MODE14) /* F14: P8.8: mcasp1_axr15.off */
+            DRA7XX_CORE_IOPAD(0x3698, MUX_MODE14) /* E17: P8.9: xref_clk1.off */
+            DRA7XX_CORE_IOPAD(0x36E8, MUX_MODE14) /* A13: P8.10: mcasp1_axr13.off */
+            DRA7XX_CORE_IOPAD(0x3510, MUX_MODE14) /* AH4: P8.11: vin1a_d7.off */
+            DRA7XX_CORE_IOPAD(0x350C, MUX_MODE14) /* AG6: P8.12: vin1a_d6.off */
+            DRA7XX_CORE_IOPAD(0x3590, PIN_INPUT | MUX_MODE12) /* D3: P8.13: vin2a_d10.off */
+            DRA7XX_CORE_IOPAD(0x3598, MUX_MODE14) /* D5: P8.14: vin2a_d12.off */
+            DRA7XX_CORE_IOPAD(0x3570, MUX_MODE14) /* D1: P8.15a: vin2a_d2.off */
+            DRA7XX_CORE_IOPAD(0x35B4, MUX_MODE13) /* A3: P8.15b: vin2a_d19.off */
+            DRA7XX_CORE_IOPAD(0x35BC, MUX_MODE13) /* B4: P8.16: vin2a_d21.off */
+            DRA7XX_CORE_IOPAD(0x3624, MUX_MODE14) /* A7: P8.17: vout1_d18.off */
+            DRA7XX_CORE_IOPAD(0x3588, PIN_INPUT | MUX_MODE12) /* F5: P8.18: vin2a_d8.off */
+            DRA7XX_CORE_IOPAD(0x358C, PIN_INPUT | MUX_MODE12) /* E6: P8.19: vin2a_d9.off */
+            DRA7XX_CORE_IOPAD(0x3780, MUX_MODE14) /* AC4: P8.20: mmc3_cmd.off */
+            DRA7XX_CORE_IOPAD(0x377C, MUX_MODE14) /* AD4: P8.21: mmc3_clk.off */
+            DRA7XX_CORE_IOPAD(0x3798, MUX_MODE14) /* AD6: P8.22: mmc3_dat5.off */
+            DRA7XX_CORE_IOPAD(0x3794, MUX_MODE14) /* AC8: P8.23: mmc3_dat4.off */
+            DRA7XX_CORE_IOPAD(0x3788, MUX_MODE14) /* AC6: P8.24: mmc3_dat1.off */
+            DRA7XX_CORE_IOPAD(0x3784, MUX_MODE14) /* AC7: P8.25: mmc3_dat0.off */
+            DRA7XX_CORE_IOPAD(0x35B8, MUX_MODE13) /* B3: P8.26: vin2a_d20.off */
+            // DRA7XX_CORE_IOPAD(0x35D8, MUX_MODE14) /* E11: P8.27a: vout1_vsync.off */
+            DRA7XX_CORE_IOPAD(0x3628, MUX_MODE14) /* A8: P8.27b: vout1_d19.off */
+            // DRA7XX_CORE_IOPAD(0x35C8, MUX_MODE14) /* D11: P8.28a: vout1_clk.off */
+            DRA7XX_CORE_IOPAD(0x362C, MUX_MODE14) /* C9: P8.28b: vout1_d20.off */
+            // DRA7XX_CORE_IOPAD(0x35D4, MUX_MODE14) /* C11: P8.29a: vout1_hsync.off */
+            DRA7XX_CORE_IOPAD(0x3630, MUX_MODE14) /* A9: P8.29b: vout1_d21.off */
+            // DRA7XX_CORE_IOPAD(0x35CC, MUX_MODE14) /* B10: P8.30a: vout1_de.off */
+            DRA7XX_CORE_IOPAD(0x3634, MUX_MODE14) /* B9: P8.30b: vout1_d22.off */
+            // DRA7XX_CORE_IOPAD(0x3614, MUX_MODE14) /* C8: P8.31a: vout1_d14.off */
+            DRA7XX_CORE_IOPAD(0x373C, MUX_MODE14) /* G16: P8.31b: mcasp4_axr0.off */
+            // DRA7XX_CORE_IOPAD(0x3618, MUX_MODE14) /* C7: P8.32a: vout1_d15.off */
+            DRA7XX_CORE_IOPAD(0x3740, MUX_MODE14) /* D17: P8.32b: mcasp4_axr1.off */
+            // DRA7XX_CORE_IOPAD(0x3610, MUX_MODE14) /* C6: P8.33a: vout1_d13.off */
+            DRA7XX_CORE_IOPAD(0x34E8, MUX_MODE14) /* AF9: P8.33b: vin1a_fld0.off */
+            // DRA7XX_CORE_IOPAD(0x3608, MUX_MODE14) /* D8: P8.34a: vout1_d11.off */
+            DRA7XX_CORE_IOPAD(0x3564, MUX_MODE14) /* G6: P8.34b: vin2a_vsync0.off */
+            // DRA7XX_CORE_IOPAD(0x360C, MUX_MODE14) /* A5: P8.35a: vout1_d12.off */
+            DRA7XX_CORE_IOPAD(0x34E4, MUX_MODE14) /* AD9: P8.35b: vin1a_de0.off */
+            // DRA7XX_CORE_IOPAD(0x3604, MUX_MODE14) /* D7: P8.36a: vout1_d10.off */
+            DRA7XX_CORE_IOPAD(0x3568, MUX_MODE14) /* F2: P8.36b: vin2a_d0.off */
+            // DRA7XX_CORE_IOPAD(0x35FC, MUX_MODE14) /* E8: P8.37a: vout1_d8.off */
+            DRA7XX_CORE_IOPAD(0x3738, MUX_MODE14) /* A21: P8.37b: mcasp4_fsx.off */
+            // DRA7XX_CORE_IOPAD(0x3600, MUX_MODE14) /* D9: P8.38a: vout1_d9.off */
+            DRA7XX_CORE_IOPAD(0x3734, MUX_MODE14) /* C18: P8.38b: mcasp4_aclkx.off */
+            // DRA7XX_CORE_IOPAD(0x35F4, MUX_MODE14) /* F8: P8.39: vout1_d6.off */
+            // DRA7XX_CORE_IOPAD(0x35F8, MUX_MODE14) /* E7: P8.40: vout1_d7.off */
+            // DRA7XX_CORE_IOPAD(0x35EC, MUX_MODE14) /* E9: P8.41: vout1_d4.off */
+            // DRA7XX_CORE_IOPAD(0x35F0, MUX_MODE14) /* F9: P8.42: vout1_d5.off */
+            // DRA7XX_CORE_IOPAD(0x35E4, MUX_MODE14) /* F10: P8.43: vout1_d2.off */
+            // DRA7XX_CORE_IOPAD(0x35E8, MUX_MODE14) /* G11: P8.44: vout1_d3.off */
+            // DRA7XX_CORE_IOPAD(0x35DC, MUX_MODE14) /* F11: P8.45a: vout1_d0.off */
+            DRA7XX_CORE_IOPAD(0x361C, MUX_MODE14) /* B7: P8.45b: vout1_d16.off */
+            // DRA7XX_CORE_IOPAD(0x35E0, MUX_MODE14) /* G10: P8.46a: vout1_d1.off */
+            DRA7XX_CORE_IOPAD(0x3638, MUX_MODE14) /* A10: P8.46b: vout1_d23.off */
+            DRA7XX_CORE_IOPAD(0x372C, MUX_MODE14) /* B19: P9.11a: mcasp3_axr0.off */
+            DRA7XX_CORE_IOPAD(0x3620, MUX_MODE14) /* B8: P9.11b: vout1_d17.off */
+            // DRA7XX_CORE_IOPAD(0x36AC, MUX_MODE14) /* B14: P9.12: mcasp1_aclkr.off */
+            DRA7XX_CORE_IOPAD(0x3730, MUX_MODE14) /* C17: P9.13: mcasp3_axr1.off */
+            // DRA7XX_CORE_IOPAD(0x35AC, MUX_MODE10) /* D6: P9.14: vin2a_d17.off */
+            // DRA7XX_CORE_IOPAD(0x3514, MUX_MODE14) /* AG4: P9.15: vin1a_d8.off */
+            // DRA7XX_CORE_IOPAD(0x35B0, MUX_MODE13) /* C5: P9.16: vin2a_d18.off */
+            DRA7XX_CORE_IOPAD(0x37CC, MUX_MODE14) /* B24: P9.17a: spi2_cs0.off */
+            DRA7XX_CORE_IOPAD(0x36B8, MUX_MODE14) /* F12: P9.17b: mcasp1_axr1.off */
+            DRA7XX_CORE_IOPAD(0x37C8, MUX_MODE14) /* G17: P9.18a: spi2_d0.off */
+            DRA7XX_CORE_IOPAD(0x36B4, MUX_MODE14) /* G12: P9.18b: mcasp1_axr0.off */
+            DRA7XX_CORE_IOPAD(0x3440, PIN_INPUT_PULLUP | MUX_MODE14) /* R6: P9.19a: gpmc_a0.i2c4_scl */
+            DRA7XX_CORE_IOPAD(0x357C, PIN_INPUT_PULLUP | MUX_MODE12 ) /* F4: P9.19b: vin2a_d5.pr1_pru1_gpi2 */
+            DRA7XX_CORE_IOPAD(0x3444, PIN_INPUT_PULLUP | MUX_MODE14) /* T9: P9.20a: gpmc_a1.i2c4_sda */
+            DRA7XX_CORE_IOPAD(0x3578, PIN_INPUT_PULLUP | MUX_MODE12) /* D2: P9.20b: vin2a_d4.pr1_pru1_gpi1 */
+            DRA7XX_CORE_IOPAD(0x34F0, MUX_MODE14) /* AF8: P9.21a: vin1a_vsync0.off */
+            DRA7XX_CORE_IOPAD(0x37C4, MUX_MODE14) /* B22: P9.21b: spi2_d1.off */
+            DRA7XX_CORE_IOPAD(0x369C, MUX_MODE14) /* B26: P9.22a: xref_clk2.off */
+            DRA7XX_CORE_IOPAD(0x37C0, MUX_MODE14) /* A26: P9.22b: spi2_sclk.off */
+            // DRA7XX_CORE_IOPAD(0x37B4, MUX_MODE14) /* A22: P9.23: spi1_cs1.off */
+            // DRA7XX_CORE_IOPAD(0x368C, MUX_MODE14) /* F20: P9.24: gpio6_15.off */
+            DRA7XX_CORE_IOPAD(0x3694, MUX_MODE14) /* D18: P9.25: xref_clk0.off */
+            DRA7XX_CORE_IOPAD(0x3688, MUX_MODE14) /* E21: P9.26a: gpio6_14.off */
+            DRA7XX_CORE_IOPAD(0x3544, MUX_MODE14) /* AE2: P9.26b: vin1a_d20.off */
+            // DRA7XX_CORE_IOPAD(0x35A0, MUX_MODE14) /* C3: P9.27a: vin2a_d14.off */
+            DRA7XX_CORE_IOPAD(0x36B0, MUX_MODE14) /* J14: P9.27b: mcasp1_fsr.off */
+            DRA7XX_CORE_IOPAD(0x36E0, MUX_MODE14) /* A12: P9.28: mcasp1_axr11.off */
+            DRA7XX_CORE_IOPAD(0x36D8, MUX_MODE14) /* A11: P9.29a: mcasp1_axr9.off */
+            DRA7XX_CORE_IOPAD(0x36A8, MUX_MODE14) /* D14: P9.29b: mcasp1_fsx.off */
+            // DRA7XX_CORE_IOPAD(0x36DC, MUX_MODE14) /* B13: P9.30: mcasp1_axr10.off */
+            DRA7XX_CORE_IOPAD(0x36D4, MUX_MODE14) /* B12: P9.31a: mcasp1_axr8.off */
+            DRA7XX_CORE_IOPAD(0x36A4, MUX_MODE14) /* C14: P9.31b: mcasp1_aclkx.off */
+            DRA7XX_CORE_IOPAD(0x36A0, MUX_MODE14) /* C23: P9.41a: xref_clk3.off */
+            DRA7XX_CORE_IOPAD(0x3580, MUX_MODE14) /* C1: P9.41b: vin2a_d6.off */
+            DRA7XX_CORE_IOPAD(0x36E4, MUX_MODE14) /* E14: P9.42a: mcasp1_axr12.off */
+            DRA7XX_CORE_IOPAD(0x359C, MUX_MODE14) /* C2: P9.42b: vin2a_d13.off */
+        >;
+    };
+};
+
+&dra7_pmx_core{
+    bb_lcd_led_pins: pinmux_bb_lcd_led_pins {
+        pinctrl-single,pins = <
+            DRA7XX_CORE_IOPAD(BBAI_P9_12, PIN_INPUT | MUX_MODE14)
+        >;
+    };
+
+    bb_lcd_pwm_backlight_pins: pinmux_bb_lcd_pwm_backlight_pins {
+        pinctrl-single,pins = <
+            DRA7XX_CORE_IOPAD(BBAI_P9_14, PIN_OUTPUT_PULLDOWN | MUX_MODE10)
+        >;
+    };
+
+    bb_lcd_lcd_pins: pinmux_bb_lcd_lcd_pins {
+        pinctrl-single,pins = <
+            DRA7XX_CORE_IOPAD(BBAI_P9_27A, PIN_OUTPUT_PULLUP | MUX_MODE14)	
+
+            DRA7XX_CORE_IOPAD(BBAI_P8_45A, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_46A, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_43, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_44, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_41, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_42, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_39, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_40, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_37A, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_38A, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_36A, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_34A, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_35A, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_33A, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_31A, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_32A, PIN_OUTPUT | MUX_MODE0)	
+
+            DRA7XX_CORE_IOPAD(BBAI_P8_27A, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_29A, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_28A, PIN_OUTPUT | MUX_MODE0)	
+            DRA7XX_CORE_IOPAD(BBAI_P8_30A, PIN_OUTPUT | MUX_MODE0)	
+        >;
+    };
+
+    bb_lcd_keymap_pins: pinmux_bb_lcd_keymap_pins {
+        pinctrl-single,pins = <
+            DRA7XX_CORE_IOPAD(BBAI_P9_15, PIN_INPUT | MUX_MODE14)	
+            DRA7XX_CORE_IOPAD(BBAI_P9_23, PIN_INPUT | MUX_MODE14)	
+            DRA7XX_CORE_IOPAD(BBAI_P9_16, PIN_INPUT | MUX_MODE14)	
+            DRA7XX_CORE_IOPAD(BBAI_P9_30, PIN_INPUT | MUX_MODE14)	
+            DRA7XX_CORE_IOPAD(BBAI_P9_24, PIN_INPUT | MUX_MODE14)	
+        >;
+    };    
+};
+
+&epwmss3 {
+    status = "okay";
+};
+
+&ehrpwm3 {
+    pinctrl-names = "default";
+    pinctrl-0 = <&bb_lcd_pwm_backlight_pins>;
+    status = "okay";
+};
+
+&dss {
+    pinctrl-names = "default";
+    pinctrl-0 = <&bb_lcd_lcd_pins>;
+    status = "okay";
+
+    port {
+        #address-cells = <1>;
+        #size-cells = <0>;
+        data-lines = <16>;
+    };
+};
+
+
+&i2c1 {
+    stmpe811@41 {
+        stmpe_touchscreen {
+            status = "okay";
+            compatible = "st,stmpe-ts";
+            /* 8 sample average control */
+            st,ave-ctrl = <3>;
+            /* 7 length fractional part in z */
+            st,fraction-z = <7>;
+            /*
+                * 50 mA typical 80 mA max touchscreen drivers
+                * current limit value
+                */
+            st,i-drive = <1>;
+            /* 1 ms panel driver settling time */
+            st,settling = <3>;
+            /* 5 ms touch detect interrupt delay */
+            st,touch-det-delay = <5>;
+
+            touchscreen-offset-x=<100>;
+            touchscreen-offset-y=<100>;
+
+            //touchscreen-inverted-x = <1>;
+            touchscreen-inverted-y = <1>;
+            //touchscreen-swapped-x-y = <1>;
+        };
+    };
+};
+
+&{/} {
+    backlight {
+        status = "okay";
+        compatible = "pwm-backlight";
+        pwms = <&ehrpwm3 0 500000 0>;
+        brightness-levels = <
+            0  1  2  3  4  5  6  7  8  9
+            10 11 12 13 14 15 16 17 18 19
+            20 21 22 23 24 25 26 27 28 29
+            30 31 32 33 34 35 36 37 38 39
+            40 41 42 43 44 45 46 47 48 49
+            50 51 52 53 54 55 56 57 58 59
+            60 61 62 63 64 65 66 67 68 69
+            70 71 72 73 74 75 76 77 78 79
+            80 81 82 83 84 85 86 87 88 89
+            90 91 92 93 94 95 96 97 98 99
+            100
+        >;
+        default-brightness-level = <100>;
+    };
+
+    gpio-leds-cape-lcd {
+        compatible = "gpio-leds";
+        pinctrl-names = "default";
+        pinctrl-0 = <&bb_lcd_led_pins>;
+
+        lcd-led0 {
+            label = "lcd:green:usr0";
+            gpios = <&gpio5 0 0>;
+            linux,default-trigger = "heartbeat";
+            default-state = "off";
+        };
+    };
+
+    gpio_keys {
+        compatible = "gpio-keys";
+        pinctrl-names = "default";
+        pinctrl-0 = <&bb_lcd_keymap_pins>;
+
+        button@1 {
+            debounce_interval = <50>;
+            linux,code = <105>;
+            label = "left";
+            gpios = <&gpio3 12 0x1>;
+            gpio-key,wakeup;
+            autorepeat;
+        };
+        button@2 {
+            debounce_interval = <50>;
+            linux,code = <106>;
+            label = "right";
+            gpios = <&gpio7 11 0x1>;
+            gpio-key,wakeup;
+            autorepeat;
+        };
+        button@3 {
+            debounce_interval = <50>;
+            linux,code = <103>;
+            label = "up";
+            gpios = <&gpio4 26 0x1>;
+            gpio-key,wakeup;
+            autorepeat;
+        };
+        button@4 {
+            debounce_interval = <50>;
+            linux,code = <108>;
+            label = "down";
+            gpios = <&gpio4 12 0x1>;
+            gpio-key,wakeup;
+            autorepeat;
+        };
+        button@5 {
+            debounce_interval = <50>;
+            linux,code = <28>;
+            label = "enter";
+            gpios = <&gpio6 15 0x1>;
+            gpio-key,wakeup;
+        };
+    };
+
+    panel {
+        status = "okay";
+        pinctrl-names = "default";
+        pinctrl-0 = <&bb_lcd_lcd_pins>;
+        panel-info {
+            ac-bias           = <255>;
+            ac-bias-intrpt    = <0>;
+            dma-burst-sz      = <16>;
+            bpp               = <16>;
+            fdd               = <0x80>;
+            sync-edge         = <0>;
+            sync-ctrl         = <1>;
+            raster-order      = <0>;
+            fifo-th           = <0>;
+        };
+        display-timings {
+            native-mode = <&timing0>;
+            /* www.newhavendisplay.com/app_notes/OTA5180A.pdf */
+            timing0: 480x272 {
+            clock-frequency = <9200000>;
+            hactive = <480>;
+            vactive = <272>;
+            hfront-porch = <8>;
+            hback-porch = <47>;
+            hsync-len = <41>;
+            vback-porch = <2>;
+            vfront-porch = <3>;
+            vsync-len = <10>;
+            hsync-active = <0>;
+            vsync-active = <0>;
+            de-active = <1>;
+            pixelclk-active = <0>;
+            };
+        };
+    };
+};


### PR DESCRIPTION
@RobertCNelson Please review my code :)
The confusion of why I2C1 is a target for touch controller is resolved when ds2 shared this schematic https://www.openhacks.com/uploadsproductos/beaglebone-lcd4-reva1-schematic.pdf