### PR TITLE
Add in/out modes to config-pin

### DIFF
--- a/tools/pmunts_muntsos/config-pin.c
+++ b/tools/pmunts_muntsos/config-pin.c
@@ -211,6 +211,7 @@ static void ConfigureMode(char *pin, char *mode, bool quiet)
   char filename[MAXPATHLEN];
   int sf;
   ssize_t len;
+  bool inout = !strcmp(mode, "out") || !strcmp(mode, "in");
 
   // Sanitize the pin name parameter
 
@@ -231,7 +232,7 @@ static void ConfigureMode(char *pin, char *mode, bool quiet)
 
   // Read the current mode file
 
-  len = write(sf, mode, strlen(mode));
+  len = inout ? write(sf, "gpio", strlen("gpio")) : write(sf, mode, strlen(mode));
   if (len < 0)
   {
     fprintf(stderr, "ERROR: write() to %s failed, %s\n", filename,
@@ -241,7 +242,7 @@ static void ConfigureMode(char *pin, char *mode, bool quiet)
 
   // Display the current mode
 
-  if (!quiet) printf("\nCurrent mode for %s is:     %s\n\n", pin, mode);
+  if (!quiet) printf("\nCurrent mode for %s is:     %s\n\n", pin, inout ? "gpio" : mode);
 
   // Close the current mode file
 

--- a/tools/pmunts_muntsos/config-pin.c
+++ b/tools/pmunts_muntsos/config-pin.c
@@ -254,7 +254,13 @@ static void ConfigureMode(char *pin, char *mode, bool quiet)
   char filename[MAXPATHLEN];
   int sf;
   ssize_t len;
-  bool inout = !strcmp(mode, "out") || !strcmp(mode, "in");
+  bool inout = !strcmp(mode, "out") || !strcmp(mode, "output") || !strcmp(mode, "in") || !strcmp(mode, "input");
+
+  // Allow for both in/out and input/output
+
+  mode = !strcmp(mode, "output") ? "out" : mode;
+  mode = !strcmp(mode, "input") ? "in" : mode;
+
 
   // Sanitize the pin name parameter
 

--- a/tools/pmunts_muntsos/config-pin.c
+++ b/tools/pmunts_muntsos/config-pin.c
@@ -71,9 +71,9 @@ static int RunShellCmd(char *cmd, char *buff, const int BUFF_SIZE) {
 // Returns -1 if fails
 static int GetGpio(char *pin) {
   char cmd[255];
-  char pin_name[255];
-  char chip[255];
-  char gpio_chip[255];
+  char pin_name[32];
+  char chip[2];
+  char gpio_chip[3];
   int gpio, status;
 
   fixup_pin_name(pin);
@@ -91,7 +91,7 @@ static int GetGpio(char *pin) {
   strcpy(cmd, "gpioinfo | grep ");
   strcat(cmd, pin);
   strcat(cmd, " -m 1 | awk '{print substr($3,2,length($3) - 2)}'");
-  status = RunShellCmd(cmd, pin_name, 255);
+  status = RunShellCmd(cmd, pin_name, sizeof(pin_name));
 
   if(status == -1 || pin_name[0] == '\0') // Check for error or empty string (meaning pin could not be found)
     return -1;
@@ -100,7 +100,7 @@ static int GetGpio(char *pin) {
   strcpy(cmd, "gpiofind ");
   strcat(cmd, pin_name);
   strcat(cmd, " | awk '{print substr($1,9)}'");
-  RunShellCmd(cmd, chip, 255);
+  RunShellCmd(cmd, chip, sizeof(chip));
 
   if(status == -1 || chip[0] == '\0') // Check for error or empty string (meaning pin could not be found)
     return -1;
@@ -109,7 +109,7 @@ static int GetGpio(char *pin) {
   strcpy(cmd, "gpiofind ");
   strcat(cmd, pin_name);
   strcat(cmd, " | awk '{print $2}'");
-  RunShellCmd(cmd, gpio_chip, 255);
+  RunShellCmd(cmd, gpio_chip, sizeof(gpio_chip));
 
   if(status == -1 || gpio_chip[0] == '\0') // Check for error or empty string (meaning pin could not be found)
     return -1;

--- a/tools/pmunts_muntsos/config-pin.c
+++ b/tools/pmunts_muntsos/config-pin.c
@@ -79,7 +79,8 @@ static int GetGpio(char *pin) {
   fixup_pin_name(pin);
 
   // Ensure pin name is valid (prevent OS injections)
-  // Must have format P[0-9]_[0-9][0-9]
+  // (must have format P[0-9]_[0-9][0-9])
+
   if(strlen(pin) != 5 || pin[0] != 'P' || !isdigit(pin[1]) || pin[2] != '_' || !isdigit(pin[3]) || !isdigit(pin[4]))
   {
     fprintf(stderr, "WARNING: invalid pin name, %s", pin,
@@ -88,6 +89,7 @@ static int GetGpio(char *pin) {
   }
 
   // Get pin name
+
   strcpy(cmd, "gpioinfo | grep ");
   strcat(cmd, pin);
   strcat(cmd, " -m 1 | awk '{print substr($3,2,length($3) - 2)}'");
@@ -97,6 +99,7 @@ static int GetGpio(char *pin) {
     return -1;
 
   // Get GPIO chip
+
   strcpy(cmd, "gpiofind ");
   strcat(cmd, pin_name);
   strcat(cmd, " | awk '{print substr($1,9)}'");
@@ -106,6 +109,7 @@ static int GetGpio(char *pin) {
     return -1;
 
   // Get GPIO number on chip
+
   strcpy(cmd, "gpiofind ");
   strcat(cmd, pin_name);
   strcat(cmd, " | awk '{print $2}'");
@@ -115,6 +119,7 @@ static int GetGpio(char *pin) {
     return -1;
 
   // Calculate sysfs GPIO number
+
   gpio = atoi(chip) * 32 + atoi(gpio_chip);
   return gpio;
 }
@@ -260,7 +265,6 @@ static void ConfigureMode(char *pin, char *mode, bool quiet)
 
   mode = !strcmp(mode, "output") ? "out" : mode;
   mode = !strcmp(mode, "input") ? "in" : mode;
-
 
   // Sanitize the pin name parameter
 

--- a/tools/pmunts_muntsos/config-pin.c
+++ b/tools/pmunts_muntsos/config-pin.c
@@ -72,7 +72,8 @@ static int RunShellCmd(char *cmd, char *buff, const int BUFF_SIZE) {
 static int GetGpio(char *pin) {
   char cmd[255];
   char pin_name[32];
-  char chip[2];
+  char gpiofind[32];
+  char chip;
   char gpio_chip[3];
   int gpio, status;
 
@@ -98,29 +99,27 @@ static int GetGpio(char *pin) {
   if(status == -1 || pin_name[0] == '\0') // Check for error or empty string (meaning pin could not be found)
     return -1;
 
-  // Get GPIO chip
+  // Get chip/GPIO info
 
   strcpy(cmd, "gpiofind ");
   strcat(cmd, pin_name);
-  strcat(cmd, " | awk '{print substr($1,9)}'");
-  RunShellCmd(cmd, chip, sizeof(chip));
+  RunShellCmd(cmd, gpiofind, sizeof(gpiofind));
 
-  if(status == -1 || chip[0] == '\0') // Check for error or empty string (meaning pin could not be found)
+  if(status == -1 || gpiofind[0] == '\0') // Check for error or empty string (meaning pin could not be found)
     return -1;
 
-  // Get GPIO number on chip
+  // Get GPIO chip (parse gpiofind output)
 
-  strcpy(cmd, "gpiofind ");
-  strcat(cmd, pin_name);
-  strcat(cmd, " | awk '{print $2}'");
-  RunShellCmd(cmd, gpio_chip, sizeof(gpio_chip));
+  chip = gpiofind[8];
 
-  if(status == -1 || gpio_chip[0] == '\0') // Check for error or empty string (meaning pin could not be found)
-    return -1;
+  // Get GPIO number on chip (parse gpiofind output)
+
+  strtok(gpiofind, " "); // Split gpiofind output at space
+  strcpy(gpio_chip, strtok(NULL, " "));
 
   // Calculate sysfs GPIO number
 
-  gpio = atoi(chip) * 32 + atoi(gpio_chip);
+  gpio = atoi(&chip) * 32 + atoi(gpio_chip);
   return gpio;
 }
 

--- a/tools/pmunts_muntsos/config-pin.c
+++ b/tools/pmunts_muntsos/config-pin.c
@@ -78,6 +78,15 @@ static int GetGpio(char *pin) {
 
   fixup_pin_name(pin);
 
+  // Ensure pin name is valid (prevent OS injections)
+  // Must have format P[0-9]_[0-9][0-9]
+  if(strlen(pin) != 5 || pin[0] != 'P' || !isdigit(pin[1]) || pin[2] != '_' || !isdigit(pin[3]) || !isdigit(pin[4]))
+  {
+    fprintf(stderr, "WARNING: invalid pin name, %s", pin,
+    strerror(errno));
+    return -1;
+  }
+
   // Get pin name
   strcpy(cmd, "gpioinfo | grep ");
   strcat(cmd, pin);


### PR DESCRIPTION
With these changes, pins can be configured with "in" and "out" modes. These modes were available in the [`config-pin`](https://github.com/beagleboard/bb.org-overlays/blob/master/tools/beaglebone-universal-io/config-pin) shell script that was used prior to switching to the C version. With the "in" mode, a pin is configured as a gpio and its direction is set to input. Similarly, with the "out" mode, a pin is configured as a gpio and its direction is set to output.

To implement this, I needed to obtain the GPIO number (e.g. gpio110) for any pin (e.g. P1_36) entered by the user. I use subprocesses to achieve this; in particularly, I call utilities from [`libgpiod`](https://github.com/brgl/libgpiod) that are included with the Debian image. There are alternatives to this approach -- e.g., creating a large struct to store all the gpio/pin data, as is done in the shell version of [`config-pin`](https://github.com/beagleboard/bb.org-overlays/blob/master/tools/beaglebone-universal-io/config-pin). The advantages/disadvantages I've identified for the subprocesses approach are given below:

**Advantages**
 - We do not have to maintain a gpio/pin struct with new board releases/updates (as long as the `libgpiod` functions continue to work)
 - Smaller file size

**Disadvantages**
 - Because I invoke subprocesses, there is technically an [OS command injection](https://owasp.org/www-community/attacks/Command_Injection) vulnerability. To help reduce this risk, I check the format of the pin entered by the user and ensure it has the proper format (P[0-9]_[0-9][0-9]):
https://github.com/beagleboard/bb.org-overlays/blob/1e0703845aa9a8615efda937d75266047dcab158/tools/pmunts_muntsos/config-pin.c#L84-L89