### PR TITLE
Bone can

### DIFF
--- a/src/arm/BONE-CAN0-00A0.dts
+++ b/src/arm/BONE-CAN0-00A0.dts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ *
+ * Virtual cape for /dev/bone/can/0 (only on BBB)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/*
+* Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+    overlays {
+        BONE-CAN0-00A0.dts = __TIMESTAMP__;
+    };
+};
+
+/*
+* Update the default pinmux of the pins.
+*/
+&ocp {
+    P9_19_pinmux { pinctrl-0 = <&P9_19_can_pin>;};  /* can rx */
+    P9_20_pinmux { pinctrl-0 = <&P9_20_can_pin>;};  /* can tx */
+};
+
+&bone_can_0 {
+    // See these files for the definition
+    // https://github.com/beagleboard/BeagleBoard-DeviceTrees/src/arm/bbai-bone-buses.dtsi
+    // https://github.com/beagleboard/BeagleBoard-DeviceTrees/src/arm/bbb-bone-buses.dtsi
+    status = "okay";
+};

--- a/src/arm/BONE-CAN1-00A0.dts
+++ b/src/arm/BONE-CAN1-00A0.dts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ *
+ * Virtual cape for /dev/bone/can/1
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/*
+* Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+    overlays {
+        BONE-CAN1-00A0.dts = __TIMESTAMP__;
+    };
+};
+
+/*
+* Update the default pinmux of the pins.
+*/
+&ocp {
+	P9_24_pinmux { pinctrl-0 = <&P9_24_can_pin>;};  /* can rx */
+    P9_26_pinmux { pinctrl-0 = <&P9_26_can_pin>;};  /* can tx */
+};
+
+&bone_can_1 {
+    // See these files for the definition
+    // https://github.com/beagleboard/BeagleBoard-DeviceTrees/src/arm/bbai-bone-buses.dtsi
+    // https://github.com/beagleboard/BeagleBoard-DeviceTrees/src/arm/bbb-bone-buses.dtsi
+    status = "okay";
+};


### PR DESCRIPTION
@jadonk @RobertCNelson please review my code :) 
Everything has been tested on BBBWL & BBAI.
The symlinks are not working for CAN (dcan) bus just like they are not working for PWM(ehrpwm) :(

If anyone wants to use the CAN bus with these overlays then, after loading the overlay they can use these commands:

```
Setting up can interface
$ sudo modprobe can-raw
$ sudo ip link set can0 up type can bitrate 125000
$ sudo ifconfig can0 up

Using can interface
$ candump can0
```

It doesn't matter which CAN bus you are using, it will always be can0 for the first, can1 for second and so on...
