### PR TITLE
Add PocketBeagle DMTimer overlays

### DIFF
--- a/src/arm/PB-PWM-TIMER-P1.20.dts
+++ b/src/arm/PB-PWM-TIMER-P1.20.dts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 Robert Nelson <robertcnelson@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+	/*
+	 * Free up the pins used by the cape from the pinmux helpers.
+	 */
+	fragment@0 {
+		target = <&ocp>;
+		__overlay__ {
+			P1_20_pinmux { status = "disabled"; };	/* gpio0_20.timer7 */
+		};
+	};
+
+	fragment@1 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			timer7_pin: pinmux_timer7_pin {
+				pinctrl-single,pins = <
+					AM33XX_IOPAD(0x09B4, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE4)	/* xdma_event_intr1.timer7 */
+				>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path="/";
+		__overlay__ {
+			dmtimer-pwm-7 {
+				pinctrl-names = "default";
+				pinctrl-0 = <&timer7_pin>;
+
+				compatible = "ti,omap-dmtimer-pwm";
+				#pwm-cells = <3>;
+				ti,timers = <&timer7>;
+				//ti,prescaler = <0>;		/* 0 thru 7 */
+				ti,clock-source = <0x00>;	/* timer_sys_ck */
+				//ti,clock-source = <0x01>;	/* timer_32k_ck */
+			};
+		};
+	};
+};

--- a/src/arm/PB-PWM-TIMER-P1.26.dts
+++ b/src/arm/PB-PWM-TIMER-P1.26.dts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 Robert Nelson <robertcnelson@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+	/*
+	 * Free up the pins used by the cape from the pinmux helpers.
+	 */
+	fragment@0 {
+		target = <&ocp>;
+		__overlay__ {
+			P1_26_pinmux { status = "disabled"; };	/* gpio0_12.timer6 */
+		};
+	};
+
+	fragment@1 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			timer6_pin: pinmux_timer6_pin {
+				pinctrl-single,pins = <
+					AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE1)	/* uart1_ctsn.timer6 */
+				>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path="/";
+		__overlay__ {
+			dmtimer-pwm-6 {
+				pinctrl-names = "default";
+				pinctrl-0 = <&timer6_pin>;
+
+				compatible = "ti,omap-dmtimer-pwm";
+				#pwm-cells = <3>;
+				ti,timers = <&timer6>;
+				//ti,prescaler = <0>;		/* 0 thru 7 */
+				ti,clock-source = <0x00>;	/* timer_sys_ck */
+				//ti,clock-source = <0x01>;	/* timer_32k_ck */
+			};
+		};
+	};
+};

--- a/src/arm/PB-PWM-TIMER-P1.28.dts
+++ b/src/arm/PB-PWM-TIMER-P1.28.dts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 Robert Nelson <robertcnelson@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+	/*
+	 * Free up the pins used by the cape from the pinmux helpers.
+	 */
+	fragment@0 {
+		target = <&ocp>;
+		__overlay__ {
+			P1_28_pinmux { status = "disabled"; };	/* gpio0_13.timer5 */
+		};
+	};
+
+	fragment@1 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			timer5_pin: pinmux_timer5_pin {
+				pinctrl-single,pins = <
+					AM33XX_IOPAD(0x097C, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE1)	/* uart1_rtsn.timer5 */
+				>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path="/";
+		__overlay__ {
+			dmtimer-pwm-5 {
+				pinctrl-names = "default";
+				pinctrl-0 = <&timer5_pin>;
+
+				compatible = "ti,omap-dmtimer-pwm";
+				#pwm-cells = <3>;
+				ti,timers = <&timer5>;
+				//ti,prescaler = <0>;		/* 0 thru 7 */
+				ti,clock-source = <0x00>;	/* timer_sys_ck */
+				//ti,clock-source = <0x01>;	/* timer_32k_ck */
+			};
+		};
+	};
+};

--- a/src/arm/PB-PWM-TIMER-P2.27.dts
+++ b/src/arm/PB-PWM-TIMER-P2.27.dts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 Robert Nelson <robertcnelson@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+	/*
+	 * Free up the pins used by the cape from the pinmux helpers.
+	 */
+	fragment@0 {
+		target = <&ocp>;
+		__overlay__ {
+			P2_27_pinmux { status = "disabled"; };	/* gpio1_08.timer7 */
+		};
+	};
+
+	fragment@1 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			timer7_pin: pinmux_timer7_pin {
+				pinctrl-single,pins = <
+					AM33XX_IOPAD(0x0968, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE5)	/* uart0_ctsn.timer7 */
+				>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path="/";
+		__overlay__ {
+			dmtimer-pwm-7 {
+				pinctrl-names = "default";
+				pinctrl-0 = <&timer7_pin>;
+
+				compatible = "ti,omap-dmtimer-pwm";
+				#pwm-cells = <3>;
+				ti,timers = <&timer7>;
+				//ti,prescaler = <0>;		/* 0 thru 7 */
+				ti,clock-source = <0x00>;	/* timer_sys_ck */
+				//ti,clock-source = <0x01>;	/* timer_32k_ck */
+			};
+		};
+	};
+};

--- a/src/arm/PB-PWM-TIMER-P2.31.dts
+++ b/src/arm/PB-PWM-TIMER-P2.31.dts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 Robert Nelson <robertcnelson@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+	/*
+	 * Free up the pins used by the cape from the pinmux helpers.
+	 */
+	fragment@0 {
+		target = <&ocp>;
+		__overlay__ {
+			P2_31_pinmux { status = "disabled"; };	/* gpio0_19.timer4 */
+		};
+	};
+
+	fragment@1 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			timer4_pin: pinmux_timer4_pin {
+				pinctrl-single,pins = <
+					AM33XX_IOPAD(0x09B0, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE2)	/* xdma_event_intr0.timer4 */
+				>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path="/";
+		__overlay__ {
+			dmtimer-pwm-4 {
+				pinctrl-names = "default";
+				pinctrl-0 = <&timer4_pin>;
+
+				compatible = "ti,omap-dmtimer-pwm";
+				#pwm-cells = <3>;
+				ti,timers = <&timer4>;
+				//ti,prescaler = <0>;		/* 0 thru 7 */
+				ti,clock-source = <0x00>;	/* timer_sys_ck */
+				//ti,clock-source = <0x01>;	/* timer_32k_ck */
+			};
+		};
+	};
+};


### PR DESCRIPTION
Add device tree overlays for using the DMTimer pins on the PocketBeagle. These overlays are analogous to the ones added in 563af29 for the BeagleBone Black. With these overlays, the following pins can be used for PWM on the PocketBeagle:

 - P1_20
 - P1_26
 - P1_28
 - P2_27
 - P2_31

These overlays have been tested on the 2020-07-13, Buster IoT testing image "bone-debian-10.4-iot-armhf-2020-07-13-4gb.img.xz," running on PocketBeagle. Additionally, they have been tested on the currently recommended Debian image ("AM3358 Debian 10.3 2020-04-06 4GB SD IoT").