### PR TITLE
Bone timer

### DIFF
--- a/src/arm/BONE-TIMER_PWM_0.dts
+++ b/src/arm/BONE-TIMER_PWM_0.dts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ *
+ * Virtual cape for /sys/devices/platform/bone_timer_pwm_0/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/*
+* Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+    overlays {
+        BONE-TIMER_PWM_0 = __TIMESTAMP__;
+    };
+};
+
+/*
+ * Update the default pinmux of the pins.
+ * See these files for the phandles (&P9_* & &P8_*)
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/am335x-bone-common-univ.dtsi
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/am572x-bone-common-univ.dtsi
+ */
+&ocp {
+    P8_10_pinmux { pinctrl-0 = <&P8_10_timer_pin>; };    /* PWM A */
+};
+
+/*
+ * See these files for the phandles (&bone_*) and other bone bus nodes
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/bbai-bone-buses.dtsi
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/bbb-bone-buses.dtsi
+ */
+&{/} {
+	bone_timer_pwm_0 {
+		compatible = "ti,omap-dmtimer-pwm";
+		#pwm-cells = <3>;
+		ti,timers = <&bone_timer_0>;
+		//ti,prescaler = <0>;		/* 0 thru 7 */
+		ti,clock-source = <0x00>;	/* timer_sys_ck */
+		//ti,clock-source = <0x01>;	/* timer_32k_ck */
+	};
+};

--- a/src/arm/BONE-TIMER_PWM_1.dts
+++ b/src/arm/BONE-TIMER_PWM_1.dts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ *
+ * Virtual cape for /sys/devices/platform/bone_timer_pwm_1/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/*
+* Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+    overlays {
+        BONE-TIMER_PWM_1 = __TIMESTAMP__;
+    };
+};
+
+/*
+ * Update the default pinmux of the pins.
+ * See these files for the phandles (&P9_* & &P8_*)
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/am335x-bone-common-univ.dtsi
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/am572x-bone-common-univ.dtsi
+ */
+&ocp {
+    P8_07_pinmux { pinctrl-0 = <&P8_07_timer_pin>; };    /* PWM A */
+};
+
+// See these files for the definition
+// https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/bbai-bone-buses.dtsi
+// https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/bbb-bone-buses.dtsi
+&{/} {
+	bone_timer_pwm_1 {
+		compatible = "ti,omap-dmtimer-pwm";
+		#pwm-cells = <3>;
+		ti,timers = <&bone_timer_1>;
+		//ti,prescaler = <0>;		/* 0 thru 7 */
+		ti,clock-source = <0x00>;	/* timer_sys_ck */
+		//ti,clock-source = <0x01>;	/* timer_32k_ck */
+	};
+};

--- a/src/arm/BONE-TIMER_PWM_2.dts
+++ b/src/arm/BONE-TIMER_PWM_2.dts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ *
+ * Virtual cape for /sys/devices/platform/bone_timer_pwm_2/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/*
+* Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+    overlays {
+        BONE-TIMER_PWM_2 = __TIMESTAMP__;
+    };
+};
+
+/*
+ * Update the default pinmux of the pins.
+ * See these files for the phandles (&P9_* & &P8_*)
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/am335x-bone-common-univ.dtsi
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/am572x-bone-common-univ.dtsi
+ */
+&ocp {
+    P8_08_pinmux { pinctrl-0 = <&P8_08_timer_pin>; };    /* PWM A */
+};
+
+// See these files for the definition
+// https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/bbai-bone-buses.dtsi
+// https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/bbb-bone-buses.dtsi
+&{/} {
+	bone_timer_pwm_2 {
+		compatible = "ti,omap-dmtimer-pwm";
+		#pwm-cells = <3>;
+		ti,timers = <&bone_timer_2>;
+		//ti,prescaler = <0>;		/* 0 thru 7 */
+		ti,clock-source = <0x00>;	/* timer_sys_ck */
+		//ti,clock-source = <0x01>;	/* timer_32k_ck */
+	};
+};

--- a/src/arm/BONE-TIMER_PWM_3.dts
+++ b/src/arm/BONE-TIMER_PWM_3.dts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ *
+ * Virtual cape for /sys/devices/platform/bone_timer_pwm_3/ (only on BBAI)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/*
+* Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+    overlays {
+        BONE-TIMER_PWM_3 = __TIMESTAMP__;
+    };
+};
+
+/*
+ * Update the default pinmux of the pins.
+ * See these files for the phandles (&P9_* & &P8_*)
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/am335x-bone-common-univ.dtsi
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/am572x-bone-common-univ.dtsi
+ */
+&ocp {
+    P9_21_pinmux { pinctrl-0 = <&P9_21_timer_pin>; };    /* PWM A */
+};
+
+// See these files for the definition
+// https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/bbai-bone-buses.dtsi
+// https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/bbb-bone-buses.dtsi
+&{/} {
+	bone_timer_pwm_3 {
+		compatible = "ti,omap-dmtimer-pwm";
+		#pwm-cells = <3>;
+		ti,timers = <&bone_timer_3>;
+		//ti,prescaler = <0>;		/* 0 thru 7 */
+		ti,clock-source = <0x00>;	/* timer_sys_ck */
+		//ti,clock-source = <0x01>;	/* timer_32k_ck */
+	};
+};

--- a/src/arm/BONE-TIMER_PWM_4.dts
+++ b/src/arm/BONE-TIMER_PWM_4.dts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ *
+ * Virtual cape for /sys/devices/platform/bone_timer_pwm_4/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/*
+* Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+    overlays {
+        BONE-TIMER_PWM_4 = __TIMESTAMP__;
+    };
+};
+
+/*
+ * Update the default pinmux of the pins.
+ * See these files for the phandles (&P9_* & &P8_*)
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/am335x-bone-common-univ.dtsi
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/am572x-bone-common-univ.dtsi
+ */
+&ocp {
+    P8_09_pinmux { pinctrl-0 = <&P8_09_timer_pin>; };    /* PWM A */
+};
+
+// See these files for the definition
+// https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/bbai-bone-buses.dtsi
+// https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/bbb-bone-buses.dtsi
+&{/} {
+	bone_timer_pwm_4 {
+		compatible = "ti,omap-dmtimer-pwm";
+		#pwm-cells = <3>;
+		ti,timers = <&bone_timer_4>;
+		//ti,prescaler = <0>;		/* 0 thru 7 */
+		ti,clock-source = <0x00>;	/* timer_sys_ck */
+		//ti,clock-source = <0x01>;	/* timer_32k_ck */
+	};
+};

--- a/src/arm/BONE-TIMER_PWM_5.dts
+++ b/src/arm/BONE-TIMER_PWM_5.dts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ *
+ * Virtual cape for /sys/devices/platform/bone_timer_pwm_5/ (only on BBAI)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/*
+ * Update the default pinmux of the pins.
+ * See these files for the phandles (&P9_* & &P8_*)
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/am335x-bone-common-univ.dtsi
+ * https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/am572x-bone-common-univ.dtsi
+ */
+&{/chosen} {
+    overlays {
+        BONE-TIMER_PWM_5 = __TIMESTAMP__;
+    };
+};
+
+/*
+* Update the default pinmux of the pins.
+*/
+&ocp {
+    P9_22_pinmux { pinctrl-0 = <&P9_22_timer_pin>; };    /* PWM A */
+};
+
+// See these files for the definition
+// https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/bbai-bone-buses.dtsi
+// https://github.com/lorforlinux/BeagleBoard-DeviceTrees/blob/compatibility/src/arm/bbb-bone-buses.dtsi
+&{/} {
+	bone_timer_pwm_5 {
+		compatible = "ti,omap-dmtimer-pwm";
+		#pwm-cells = <3>;
+		ti,timers = <&bone_timer_5>;
+		//ti,prescaler = <0>;		/* 0 thru 7 */
+		ti,clock-source = <0x00>;	/* timer_sys_ck */
+		//ti,clock-source = <0x01>;	/* timer_32k_ck */
+	};
+};


### PR DESCRIPTION
@jadonk @RobertCNelson please review my code :) Everything has been tested on BBWL & BBAI

@RobertCNelson I noticed that on BBBWL I had to export the PWM channels but on BBAI it automatically does it for me. I confirmed that the patch -> https://github.com/beagleboard/customizations/commit/6377ab09d91abd69bf67c8b9bbb9c97e7eb4be7d you mentioned on slack is installed on BBAI but it's still automatically exporting PWM channels. I am unable to run the LCD Backlight on BBAI please let me know how you got your LCD7 working on BBAI.