### PR TITLE
Update MIKROBUS PB Overlays

### DIFF
--- a/src/arm/PB-MIKROBUS-0.dts
+++ b/src/arm/PB-MIKROBUS-0.dts
@@ -66,6 +66,7 @@
 		target = <&uart4>;
 		__overlay__ {
 			status = "okay";
+			force-empty-serdev-controller;
 		};
 	};
 
@@ -126,7 +127,7 @@
 				i2c-adapter = <&i2c1>;
 				spi-master = <0>;
 				spi-cs = <0 1>;
-				serdev-controller = <&uart4>;
+				uart = <&uart4>;
 				pwms = <&ehrpwm1 0 500000 0>;
 				mikrobus-gpios = <&gpio1 18 0> , <&gpio0 23 0>,
 						 <&gpio0 30 0> , <&gpio0 31 0>,

--- a/src/arm/PB-MIKROBUS-1.dts
+++ b/src/arm/PB-MIKROBUS-1.dts
@@ -67,6 +67,7 @@
 		target = <&uart0>;
 		__overlay__ {
 			status = "okay";
+			force-empty-serdev-controller;
 		};
 	};
 
@@ -127,7 +128,7 @@
 				i2c-adapter = <&i2c2>;
 				spi-master = <1>;
 				spi-cs = <1 2>;
-				serdev-controller = <&uart0>;
+				uart = <&uart0>;
 				pwms = <&ehrpwm0 0 500000 0>;
 				mikrobus-gpios = <&gpio3 14 0> , <&gpio0 26 0>,
 						 <&gpio1 10 0> , <&gpio1 11 0>,


### PR DESCRIPTION
Hi @RobertCNelson ,

This is a minor update in the overlay which will be required for testing GNSS/GPS Clicks.

add force-empty-serdev-controller field, this is necessary to create an empty serdev controller(when there is no serdev child nodes defined in DT).