### PR TITLE
mikrobus: Add Overlays for mikroBUS Cape Ports

### DIFF
--- a/src/arm/BB-MIKROBUS-CAPE-1.dts
+++ b/src/arm/BB-MIKROBUS-CAPE-1.dts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2020 Robert Nelson <robertcnelson@gmail.com>
+ * Copyright 2020 Vaishnav M A, BeagleBoard.org Foundation.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+
+	/*
+	 * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+	 */
+	fragment@0 {
+		target-path="/";
+		__overlay__ {
+
+			chosen {
+				overlays {
+					BB-MIKROBUS-CAPE-1 = __TIMESTAMP__;
+				};
+			};
+		};
+	};
+
+	/*
+	 * Free up the pins used by the mikrobus port from the pinmux helpers.
+	 * pins are listed in clockwise order of their appearance in the
+	 * mikrobus port.
+	 */
+	fragment@1 {
+		target = <&ocp>;
+		__overlay__ {			
+
+			P9_14_pinmux { status = "disabled"; };
+			P9_15_pinmux { status = "disabled"; };
+			P9_21_pinmux { status = "disabled"; };
+			P9_22_pinmux { status = "disabled"; };
+			P9_19_pinmux { status = "disabled"; };
+			P9_20_pinmux { status = "disabled"; };
+			P9_30_pinmux { status = "disabled"; };
+			P9_29_pinmux { status = "disabled"; };
+			P9_31_pinmux { status = "disabled"; };
+			P9_28_pinmux { status = "disabled"; };
+			P9_12_pinmux { status = "disabled"; };
+			P8_26_pinmux { status = "disabled"; };
+		};
+	};
+
+	fragment@2 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			mbc_spi1_pins: pinmux-mbc-spi1-pins {
+					pinctrl-single,pins = <
+						AM33XX_IOPAD(0x0990, PIN_INPUT | MUX_MODE3 ) /* P9_31 (A13) mcasp0_aclkx.spi1_sclk */
+						AM33XX_IOPAD(0x0994, PIN_INPUT | MUX_MODE3 ) /* P9_29 (B13) mcasp0_fsx.spi1_d0 */
+						AM33XX_IOPAD(0x0998, PIN_INPUT | MUX_MODE3 ) /* P9_30 (D12) mcasp0_axr0.spi1_d1 */
+					>;
+				};
+			};
+	};
+
+	fragment@3 {
+		target = <&spi1>;
+		__overlay__ {
+			status = "okay";
+			cs-gpios = <0>, <0>, <&gpio1 28 GPIO_ACTIVE_HIGH>, <&gpio1 17 GPIO_ACTIVE_HIGH>,
+				   <&gpio2 4 GPIO_ACTIVE_HIGH>, <&gpio1 14 GPIO_ACTIVE_HIGH>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&mbc_spi1_pins>;
+			channel@0{ status = "disabled"; };
+			channel@1{ status = "disabled"; };
+		};
+	};
+
+	fragment@4 {
+		target = <&uart2>;
+		__overlay__ {
+			status = "okay";
+			force-empty-serdev-controller;
+		};
+	};
+
+	fragment@5 {
+		target-path="/";
+		__overlay__ {
+
+			aliases {
+				mikrobus1 = "/mikrobus-1";
+			};
+		};
+	};
+
+	fragment@6 {
+		target-path="/";
+		__overlay__ {
+			mikrobus-1 {
+				compatible = "linux,mikrobus";
+				status = "okay";
+				pinctrl-names = "default", "pwm_default", "pwm_gpio",
+						"uart_default", "uart_gpio", "i2c_default",
+						"i2c_gpio", "spi_default", "spi_gpio";
+				pinctrl-0 = <
+					&P9_15_gpio_input_pin
+					&P9_12_gpio_pin
+					&P8_26_gpio_pin
+				>;
+				pinctrl-1 = <&P9_14_pwm_pin>;
+				pinctrl-2 = <&P9_14_gpio_pin>;
+				/* Disable below if Cape UART/SPI Selectors are
+				 * in SPI Position
+				 */		
+				pinctrl-3 = <
+					&P9_21_uart_pin
+					&P9_22_uart_pin
+				>;
+				pinctrl-4 = <
+					&P9_21_gpio_pin
+					&P9_22_gpio_pin
+				>;				
+				pinctrl-5 = <>;/*hack, will be fixed in next mikrobus driver revision*/
+				pinctrl-6 = <>;
+				pinctrl-7 = <
+					&P9_28_spi_cs_pin
+				>;
+				pinctrl-8 = <
+					&P9_28_gpio_pin
+				>;
+				i2c-adapter = <&i2c2>;
+				spi-master = <1>;
+				spi-cs = <0 2>;
+				uart = <&uart2>;
+				pwms = <&ehrpwm1 0 500000 0>;
+				mikrobus-gpios = <&gpio1 18 0> , <&gpio1 16 0>,
+						 <&gpio0 3 0> , <&gpio0 2 0>,
+						 <&gpio0 13 0> , <&gpio0 12 0>,
+						 <&gpio3 16 0> , <&gpio3 15 0>,
+						 <&gpio3 14 0> , <&gpio3 17 0>,
+						 <&gpio1 28 0> , <&gpio1 29 0>;
+			};
+		};
+	};
+};

--- a/src/arm/BB-MIKROBUS-CAPE-2.dts
+++ b/src/arm/BB-MIKROBUS-CAPE-2.dts
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2020 Robert Nelson <robertcnelson@gmail.com>
+ * Copyright 2020 Vaishnav M A, BeagleBoard.org Foundation.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+
+	/*
+	 * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+	 */
+	fragment@0 {
+		target-path="/";
+		__overlay__ {
+
+			chosen {
+				overlays {
+					BB-MIKROBUS-CAPE-2 = __TIMESTAMP__;
+				};
+			};
+		};
+	};
+
+	/*
+	 * Free up the pins used by the mikrobus port from the pinmux helpers.
+	 * pins are listed in clockwise order of their appearance in the
+	 * mikrobus port.
+	 */
+	fragment@1 {
+		target = <&ocp>;
+		__overlay__ {			
+
+			P9_16_pinmux { status = "disabled"; };
+			P9_41_pinmux { status = "disabled"; };
+			P9_26_pinmux { status = "disabled"; };
+			P9_24_pinmux { status = "disabled"; };
+			P9_19_pinmux { status = "disabled"; };
+			P9_20_pinmux { status = "disabled"; };
+			P9_30_pinmux { status = "disabled"; };
+			P9_29_pinmux { status = "disabled"; };
+			P9_31_pinmux { status = "disabled"; };
+			P9_42_pinmux { status = "disabled"; };
+			P9_23_pinmux { status = "disabled"; };
+			P8_15_pinmux { status = "disabled"; };
+		};
+	};
+
+	fragment@2 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			mbc_spi1_pins: pinmux-mbc-spi1-pins {
+					pinctrl-single,pins = <
+						AM33XX_IOPAD(0x0990, PIN_INPUT | MUX_MODE3 ) /* P9_31 (A13) mcasp0_aclkx.spi1_sclk */
+						AM33XX_IOPAD(0x0994, PIN_INPUT | MUX_MODE3 ) /* P9_29 (B13) mcasp0_fsx.spi1_d0 */
+						AM33XX_IOPAD(0x0998, PIN_INPUT | MUX_MODE3 ) /* P9_30 (D12) mcasp0_axr0.spi1_d1 */
+					>;
+				};
+			};
+	};
+
+	fragment@3 {
+		target = <&spi1>;
+		__overlay__ {
+			status = "okay";
+			cs-gpios = <0>, <0>, <&gpio1 28 GPIO_ACTIVE_HIGH>, <&gpio1 17 GPIO_ACTIVE_HIGH>,
+				   <&gpio2 4 GPIO_ACTIVE_HIGH>, <&gpio1 14 GPIO_ACTIVE_HIGH>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&mbc_spi1_pins>;
+			channel@0{ status = "disabled"; };
+			channel@1{ status = "disabled"; };
+		};
+	};
+
+	fragment@4 {
+		target = <&uart2>;
+		__overlay__ {
+			status = "okay";
+			force-empty-serdev-controller;
+		};
+	};
+
+	fragment@5 {
+		target-path="/";
+		__overlay__ {
+
+			aliases {
+				mikrobus2 = "/mikrobus-2";
+			};
+		};
+	};
+
+	fragment@6 {
+		target-path="/";
+		__overlay__ {
+			mikrobus-2 {
+				compatible = "linux,mikrobus";
+				status = "okay";
+				pinctrl-names = "default", "pwm_default", "pwm_gpio",
+						"uart_default", "uart_gpio", "i2c_default",
+						"i2c_gpio", "spi_default", "spi_gpio";
+				pinctrl-0 = <
+					&P9_41_gpio_input_pin
+					&P9_23_gpio_pin
+					&P8_15_gpio_pin
+				>;
+				pinctrl-1 = <&P9_16_pwm_pin>;
+				pinctrl-2 = <&P9_16_gpio_pin>;		
+				pinctrl-3 = <
+					&P9_26_uart_pin
+					&P9_24_uart_pin
+				>;
+				pinctrl-4 = <
+					&P9_26_gpio_pin
+					&P9_24_gpio_pin
+				>;				
+				pinctrl-5 = <>;/*hack, will be fixed in next mikrobus driver revision*/
+				pinctrl-6 = <>;
+				pinctrl-7 = <
+					&P9_42_spi_cs_pin
+				>;
+				pinctrl-8 = <
+					&P9_42_gpio_pin
+				>;
+				i2c-adapter = <&i2c2>;
+				spi-master = <1>;
+				spi-cs = <1 3>;
+				uart = <&uart2>;
+				pwms = <&ehrpwm1 1 500000 0>;
+				mikrobus-gpios = <&gpio1 19 0> , <&gpio3 20 0>,
+						 <&gpio0 15 0> , <&gpio0 14 0>,
+						 <&gpio0 13 0> , <&gpio0 12 0>,
+						 <&gpio3 16 0> , <&gpio3 15 0>,
+						 <&gpio3 14 0> , <&gpio0 7 0>,
+						 <&gpio1 17 0> , <&gpio1 15 0>;
+			};
+		};
+	};
+};

--- a/src/arm/BB-MIKROBUS-CAPE-3.dts
+++ b/src/arm/BB-MIKROBUS-CAPE-3.dts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2020 Robert Nelson <robertcnelson@gmail.com>
+ * Copyright 2020 Vaishnav M A, BeagleBoard.org Foundation.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+
+	/*
+	 * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+	 */
+	fragment@0 {
+		target-path="/";
+		__overlay__ {
+
+			chosen {
+				overlays {
+					BB-MIKROBUS-CAPE-3 = __TIMESTAMP__;
+				};
+			};
+		};
+	};
+
+	/*
+	 * Free up the pins used by the mikrobus port from the pinmux helpers.
+	 * pins are listed in clockwise order of their appearance in the
+	 * mikrobus port.
+	 */
+	fragment@1 {
+		target = <&ocp>;
+		__overlay__ {			
+
+			P8_19_pinmux { status = "disabled"; };
+			P8_18_pinmux { status = "disabled"; };
+			P9_24_pinmux { status = "disabled"; };
+			P9_26_pinmux { status = "disabled"; };
+			P9_19_pinmux { status = "disabled"; };
+			P9_20_pinmux { status = "disabled"; };
+			P9_18_pinmux { status = "disabled"; };
+			P9_21_pinmux { status = "disabled"; };
+			P9_22_pinmux { status = "disabled"; };
+			P9_17_pinmux { status = "disabled"; };
+			P8_14_pinmux { status = "disabled"; };
+			P8_12_pinmux { status = "disabled"; };
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+			cs-gpios = <0>, <0>, <&gpio0 26 GPIO_ACTIVE_HIGH>;
+			channel@0{ status = "disabled"; };
+			channel@1{ status = "disabled"; };
+		};
+	};
+
+	fragment@3 {
+		target = <&uart1>;
+		__overlay__ {
+			status = "okay";
+			force-empty-serdev-controller;
+		};
+	};
+
+	fragment@4 {
+		target-path="/";
+		__overlay__ {
+
+			aliases {
+				mikrobus3 = "/mikrobus-3";
+			};
+		};
+	};
+
+	fragment@5 {
+		target-path="/";
+		__overlay__ {
+			mikrobus-3 {
+				compatible = "linux,mikrobus";
+				status = "okay";
+				pinctrl-names = "default", "pwm_default", "pwm_gpio",
+						"uart_default", "uart_gpio", "i2c_default",
+						"i2c_gpio", "spi_default", "spi_gpio";
+				pinctrl-0 = <
+					&P8_18_gpio_input_pin
+					&P8_14_gpio_pin
+					&P8_12_gpio_pin
+				>;
+				pinctrl-1 = <&P8_19_pwm_pin>;
+				pinctrl-2 = <&P8_19_gpio_pin>;		
+				pinctrl-3 = <
+					&P9_24_uart_pin
+					&P9_26_uart_pin
+				>;
+				pinctrl-4 = <
+					&P9_24_gpio_pin
+					&P9_26_gpio_pin
+				>;				
+				pinctrl-5 = <>;/*hack, will be fixed in next mikrobus driver revision*/
+				pinctrl-6 = <>;
+				pinctrl-7 = <
+				/* Enable below if UART/SPI Selectors are
+				 * in SPI Position
+				 */
+				 /* disabled by default
+					&P9_18_spi_pin
+					&P9_21_spi_pin
+					&P9_22_spi_sclk_pin
+					&P9_17_spi_cs_pin
+				*/
+				>;
+				pinctrl-8 = <
+				/* disabled by default
+					&P9_18_gpio_pin
+					&P9_21_gpio_pin
+					&P9_22_gpio_pin
+					&P9_17_gpio_pin
+				*/
+				>;
+				i2c-adapter = <&i2c2>;
+				spi-master = <0>;
+				spi-cs = <0 2>;
+				uart = <&uart1>;
+				pwms = <&ehrpwm2 0 500000 0>;
+				mikrobus-gpios = <&gpio0 22 0> , <&gpio2 1 0>,
+						 <&gpio0 15 0> , <&gpio0 14 0>,
+						 <&gpio0 13 0> , <&gpio0 12 0>,
+						 <&gpio0 4 0> , <&gpio0 3 0>,
+						 <&gpio0 2 0> , <&gpio0 5 0>,
+						 <&gpio0 26 0> , <&gpio1 12 0>;
+			};
+		};
+	};
+};

--- a/src/arm/BB-MIKROBUS-CAPE-4.dts
+++ b/src/arm/BB-MIKROBUS-CAPE-4.dts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2020 Robert Nelson <robertcnelson@gmail.com>
+ * Copyright 2020 Vaishnav M A, BeagleBoard.org Foundation.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+
+	/*
+	 * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+	 */
+	fragment@0 {
+		target-path="/";
+		__overlay__ {
+
+			chosen {
+				overlays {
+					BB-MIKROBUS-CAPE-4 = __TIMESTAMP__;
+				};
+			};
+		};
+	};
+
+	/*
+	 * Free up the pins used by the mikrobus port from the pinmux helpers.
+	 * pins are listed in clockwise order of their appearance in the
+	 * mikrobus port.
+	 */
+	fragment@1 {
+		target = <&ocp>;
+		__overlay__ {			
+
+			P8_13_pinmux { status = "disabled"; };
+			P8_17_pinmux { status = "disabled"; };
+			P9_13_pinmux { status = "disabled"; };
+			P9_11_pinmux { status = "disabled"; };
+			P9_19_pinmux { status = "disabled"; };
+			P9_20_pinmux { status = "disabled"; };
+			P9_30_pinmux { status = "disabled"; };
+			P9_29_pinmux { status = "disabled"; };
+			P9_31_pinmux { status = "disabled"; };
+			P8_10_pinmux { status = "disabled"; };
+			P8_16_pinmux { status = "disabled"; };
+			P8_11_pinmux { status = "disabled"; };
+		};
+	};
+
+	fragment@2 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			mbc_spi1_pins: pinmux-mbc-spi1-pins {
+					pinctrl-single,pins = <
+						AM33XX_IOPAD(0x0990, PIN_INPUT | MUX_MODE3 ) /* P9_31 (A13) mcasp0_aclkx.spi1_sclk */
+						AM33XX_IOPAD(0x0994, PIN_INPUT | MUX_MODE3 ) /* P9_29 (B13) mcasp0_fsx.spi1_d0 */
+						AM33XX_IOPAD(0x0998, PIN_INPUT | MUX_MODE3 ) /* P9_30 (D12) mcasp0_axr0.spi1_d1 */
+					>;
+				};
+			};
+	};
+
+	fragment@3 {
+		target = <&spi1>;
+		__overlay__ {
+			status = "okay";
+			cs-gpios = <0>, <0>, <&gpio1 28 GPIO_ACTIVE_HIGH>, <&gpio1 17 GPIO_ACTIVE_HIGH>,
+				   <&gpio2 4 GPIO_ACTIVE_HIGH>, <&gpio1 14 GPIO_ACTIVE_HIGH>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&mbc_spi1_pins>;
+			channel@0{ status = "disabled"; };
+			channel@1{ status = "disabled"; };
+		};
+	};
+
+	fragment@4 {
+		target = <&uart4>;
+		__overlay__ {
+			status = "okay";
+			force-empty-serdev-controller;
+		};
+	};
+
+	fragment@5 {
+		target-path="/";
+		__overlay__ {
+
+			aliases {
+				mikrobus4 = "/mikrobus-4";
+			};
+		};
+	};
+
+	fragment@6 {
+		target-path="/";
+		__overlay__ {
+			mikrobus-4 {
+				compatible = "linux,mikrobus";
+				status = "okay";
+				pinctrl-names = "default", "pwm_default", "pwm_gpio",
+						"uart_default", "uart_gpio", "i2c_default",
+						"i2c_gpio", "spi_default", "spi_gpio";
+				pinctrl-0 = <
+					&P8_17_gpio_input_pin
+					&P8_16_gpio_pin
+					&P8_11_gpio_pin	
+					&P8_10_gpio_pin
+				>;
+				pinctrl-1 = <&P8_13_pwm_pin>;
+				pinctrl-2 = <&P8_13_gpio_pin>;		
+				pinctrl-3 = <
+					&P9_13_uart_pin
+					&P9_11_uart_pin
+				>;
+				pinctrl-4 = <
+					&P9_13_gpio_pin
+					&P9_11_gpio_pin
+				>;				
+				pinctrl-5 = <>;/*hack, will be fixed in next mikrobus driver revision*/
+				pinctrl-6 = <>;
+				pinctrl-7 = <>;
+				pinctrl-8 = <>;
+				i2c-adapter = <&i2c2>;
+				spi-master = <1>;
+				spi-cs = <4 5>;
+				uart = <&uart4>;
+				pwms = <&ehrpwm2 1 500000 0>;
+				mikrobus-gpios = <&gpio0 23 0> , <&gpio0 27 0>,
+						 <&gpio0 31 0> , <&gpio0 30 0>,
+						 <&gpio0 13 0> , <&gpio0 12 0>,
+						 <&gpio3 16 0> , <&gpio3 15 0>,
+						 <&gpio3 14 0> , <&gpio2 4 0>,
+						 <&gpio1 14 0> , <&gpio1 13 0>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Hi @RobertCNelson ,

Tested on BeagleBone Black Wireless with the mikroBUS cape and miikroBUS driver latest patch(serdev), should
work perfectly with the previous/v2 patch as well.Original Pull request submission: https://github.com/beagleboard/bb.org-overlays/pull/200 was closed accidentally.

Changes from original PR:
	- @RobertCNelson  's suggested fix to split all spi1 pins to a common
	  pinmux same for all the overlays(port 1,2,4)- tested with SPI clicks
	 on the ports.
	- rename mikrobus alias from 0-indexed to 1-indexed so that there is no confusion 
	 between ports on the mikrobus cape.