### PR TITLE
add dts for LTC2947 on SPI1 of BeagleBoneBlack

### DIFF
--- a/src/arm/BB-SPI1-LTC2947-00A0.dts
+++ b/src/arm/BB-SPI1-LTC2947-00A0.dts
@@ -28,6 +28,7 @@
 		"P9.29",	/* spi1_d0 */
 		"P9.30",	/* spi1_d1 */
 		"P9.28",	/* spi1_cs0 */
+		"P9.42",	/* spi1_cs1 */
 		/* the hardware ip uses */
 		"spi1";
 
@@ -53,6 +54,7 @@
 		target = <&ocp>;
 		__overlay__ {
 			P9_28_pinmux { status = "disabled"; };	/* spi1_cs0 */
+			P9_42_pinmux { status = "disabled"; };	/* spi1_cs1 */
 			P9_30_pinmux { status = "disabled"; };	/* spi1_d1 */
 			P9_29_pinmux { status = "disabled"; };	/* spi1_d0 */
 			P9_31_pinmux { status = "disabled"; };	/* spi1_sclk */
@@ -69,6 +71,7 @@
 					0x194 0x33	/* mcasp0_fsx.spi1_d0, INPUT_PULLUP | MODE3 */
 					0x198 0x13	/* mcasp0_axr0.spi1_d1, OUTPUT_PULLUP | MODE3 */
 					0x19c 0x13	/* mcasp0_ahclkr.spi1_cs0, OUTPUT_PULLUP | MODE3 */
+					0x164 0x12	/* eCAP0_in_PWM0_out.spi1_cs1 OUTPUT_PULLUP | MODE2 */
 				>;
 			};
 		};
@@ -85,13 +88,22 @@
 			pinctrl-0 = <&bb_spi1_pins>;
 			ti,pio-mode; /* disable dma when used as an overlay, dma gets stuck at 160 bits... */
 
-			ltc2947_spi: ltc2947@0 {
+			ltc2947_spi1_0: ltc2947@0 {
 				#address-cells = <1>;
 				#size-cells = <0>;
 
 				compatible = "adi,ltc2947";
 
 				reg = <0>;
+				spi-max-frequency = <1000000>;
+			};
+			ltc2947_spi1_1: ltc2947@1 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				compatible = "adi,ltc2947";
+
+				reg = <1>;
 				spi-max-frequency = <1000000>;
 			};
 		};

--- a/src/arm/BB-SPI1-LTC2947-00A0.dts
+++ b/src/arm/BB-SPI1-LTC2947-00A0.dts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2020 Otter Works
+ *
+ * LTC2947 on SPI1
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/board/am335x-bbw-bbb-base.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+	compatible = "ti,beaglebone", "ti,beaglebone-black", "ti,beaglebone-green";
+
+	/* identification */
+	part-number = "BB-SPI1-LTC2947";
+	version = "00A0";
+
+	/* state the resources this cape uses */
+	exclusive-use =
+		/* the pin header uses */
+		"P9.31",	/* spi1_sclk */
+		"P9.29",	/* spi1_d0 */
+		"P9.30",	/* spi1_d1 */
+		"P9.28",	/* spi1_cs0 */
+		/* the hardware ip uses */
+		"spi1";
+
+	/*
+	 * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+	 */
+	fragment@0 {
+		target-path="/";
+		__overlay__ {
+
+			chosen {
+				overlays {
+					BB-SPI1-LTC2947-00A0 = __TIMESTAMP__;
+				};
+			};
+		};
+	};
+
+	/*
+	 * Free up the pins used by the cape from the pinmux helpers.
+	 */
+	fragment@1 {
+		target = <&ocp>;
+		__overlay__ {
+			P9_28_pinmux { status = "disabled"; };	/* spi1_cs0 */
+			P9_30_pinmux { status = "disabled"; };	/* spi1_d1 */
+			P9_29_pinmux { status = "disabled"; };	/* spi1_d0 */
+			P9_31_pinmux { status = "disabled"; };	/* spi1_sclk */
+		};
+	};
+
+	fragment@2 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			/* default state has all gpios released and mode set to uart1 */
+			bb_spi1_pins: pinmux_bb_spi1_pins {
+				pinctrl-single,pins = <
+					0x190 0x33	/* mcasp0_aclkx.spi1_sclk, INPUT_PULLUP | MODE3 */
+					0x194 0x33	/* mcasp0_fsx.spi1_d0, INPUT_PULLUP | MODE3 */
+					0x198 0x13	/* mcasp0_axr0.spi1_d1, OUTPUT_PULLUP | MODE3 */
+					0x19c 0x13	/* mcasp0_ahclkr.spi1_cs0, OUTPUT_PULLUP | MODE3 */
+				>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&bb_spi1_pins>;
+			ti,pio-mode; /* disable dma when used as an overlay, dma gets stuck at 160 bits... */
+
+			ltc2947_spi: ltc2947@0 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				compatible = "adi,ltc2947";
+
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
I've tested this with 2x [VCP Monitor 3 click](https://www.mikroe.com/vcp-monitor-3-click) boards in slots 1 & 2 of the MikroBus cape.

For linux kernel driver support, you need to update to kernel 5.4.70-ti-r19 (or another 5.4.x), then compile and install the modules from mainline. I've made a small repo for out-of-tree module compilation [here](https://gitlab.com/bluesquall/kmod-ltc2947) (and I'll probably mirror it on github later).