### PR TITLE
Added overlay of SSD1306 on I2C1

### DIFF
--- a/src/arm/BB-I2C1-SSD1306.dts
+++ b/src/arm/BB-I2C1-SSD1306.dts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2021 Thales Silva <thales.tas@gmail.com>
+ *
+ * SSD1306 cape using
+ * I2C1 on connector pin P9.17 P9.19
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/board/am335x-bbw-bbb-base.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+	compatible = "ti,beaglebone", "ti,beaglebone-black", "ti,beaglebone-green";
+
+	// identification
+	part-number = "BB-I2C1-SSD1306";
+	version = "00A0";
+
+	// resources this cape uses
+	exclusive-use =
+		"P9.18",	// i2c1_sda
+		"P9.17",	// i2c1_scl
+
+		"i2c1";		// hardware ip used
+
+	/*
+	 * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+	 */
+	fragment@0 {
+		target-path="/";
+		__overlay__ {
+
+			chosen {
+				overlays {
+					BB-I2C1-SSD1306 = __TIMESTAMP__;
+				};
+			};
+		};
+	};
+
+	/*
+	 * Free up the pins used by the cape from the pinmux helpers.
+	 */
+	fragment@1 {
+		target = <&ocp>;
+		__overlay__ {
+			P9_17_pinmux { status = "disabled"; };	/* i2c1_scl */
+			P9_18_pinmux { status = "disabled"; };	/* i2c1_sda */
+		};
+	};
+
+	fragment@2 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			bb_i2c1_pins: pinmux_bb_i2c1_pins {
+				pinctrl-single,pins = <
+					BONE_P9_18 0x72	/* spi0_d1.i2c1_sda, SLEWCTRL_SLOW | INPUT_PULLUP | MODE2 */
+					BONE_P9_17 0x72	/* spi0_cs0.i2c1_scl, SLEWCTRL_SLOW | INPUT_PULLUP | MODE2 */
+				>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&i2c1>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&bb_i2c1_pins>;
+
+			/* this is the configuration part */
+			clock-frequency = <400000>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ssd1306: oled@3c {
+				compatible = "solomon,ssd1306fb-i2c";
+				reg = <0x3c>;
+				solomon,width = <128>;
+				solomon,height = <64>;
+				solomon,com-invdir;
+				solomon,page-offset = <0>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
It was tested using OLED SSD1306 0.96 display on BealgeBone Black.

Device Driver FB_SSD1307 is already built-in kernel 4.19.94-ti-r42.