### PR TITLE
added overlay of ADS1115 on I2C1

### DIFF
--- a/src/arm/BB-I2C1-ADS1115.dts
+++ b/src/arm/BB-I2C1-ADS1115.dts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2021 Thales Silva <thales.tas@gmail.com>
+ *
+ * ADS1115 cape using
+ * I2C1 on connector pin P9.17 P9.19
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/board/am335x-bbw-bbb-base.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+	/*
+	 * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+	 */
+	fragment@0 {
+		target-path="/";
+		__overlay__ {
+
+			chosen {
+				overlays {
+					BB-I2C1-SSD1306 = __TIMESTAMP__;
+				};
+			};
+		};
+	};
+
+	/*
+	 * Free up the pins used by the cape from the pinmux helpers.
+	 */
+	fragment@1 {
+		target = <&ocp>;
+		__overlay__ {
+			P9_17_pinmux { status = "disabled"; };	/* i2c1_scl */
+			P9_18_pinmux { status = "disabled"; };	/* i2c1_sda */
+		};
+	};
+
+	fragment@2 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			bb_i2c1_pins: pinmux_bb_i2c1_pins {
+				pinctrl-single,pins = <
+					BONE_P9_18 0x72	/* spi0_d1.i2c1_sda, SLEWCTRL_SLOW | INPUT_PULLUP | MODE2 */
+					BONE_P9_17 0x72	/* spi0_cs0.i2c1_scl, SLEWCTRL_SLOW | INPUT_PULLUP | MODE2 */
+				>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&i2c1>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&bb_i2c1_pins>;
+
+			/* this is the configuration part */
+			clock-frequency = <400000>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ads1115: adc@48 {
+				compatible = "ti,ads1015";
+				reg = <0x48>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				channel@0{
+					reg = <0>;
+				};
+				channel@1{
+					reg = <1>;
+				};
+				channel@2{
+					reg = <2>;
+				};
+				channel@3{
+					reg = <3>;
+				};
+				channel@4{
+					reg = <4>;
+				};
+				channel@5{
+					reg = <5>;
+				};
+				channel@6{
+					reg = <6>;
+				};
+				channel@7{
+					reg = <7>;
+				};
+			};
+		};
+	};
+};


### PR DESCRIPTION
The ADS1115 is a popular ADC IC. There are some modules based on it.
It was tested using a similar [Adafruit Breakout Board](https://www.adafruit.com/product/1085) and [ADS1015 device driver](https://www.kernel.org/doc/html/v5.2/hwmon/ads1015.html).