### PR TITLE
Update cape-unversal-pwm.txt

### DIFF
--- a/examples/cape-unversal-pwm.txt
+++ b/examples/cape-unversal-pwm.txt
@@ -14,7 +14,7 @@ so grep:
 #ls -lh /sys/devices/platform/ocp/48300000.epwmss/48300200.pwm/pwm/
 #P9.14/P9.16
 #ls -lh /sys/devices/platform/ocp/48302000.epwmss/48302200.pwm/pwm/
-#P8.13/P8.16
+#P8.13/P8.19
 #ls -lh /sys/devices/platform/ocp/48304000.epwmss/48304200.pwm/pwm/
 
 export ehrpwm0=/sys/devices/platform/ocp/48300000.epwmss/48300200.pwm/pwm/pwmchip0


### PR DESCRIPTION
Correct the value of the pin.
It should have been P8_19 instead of P8_16

| Pin   | $PINS | ADDR      | GPIO | Name     |
|-------|-------|-----------|------|----------|
| P8_19 | 8     | 0x820/020 | 22   | EHRPWM2A |