### PR TITLE
DTS for Audio cape on PB

### DIFF
--- a/src/arm/PB-BONE-AUDI-02-00A0.dts
+++ b/src/arm/PB-BONE-AUDI-02-00A0.dts
@@ -1,6 +1,10 @@
-// SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (C) 2012 Texas Instruments Incorporated - https://www.ti.com/
+ * Peter Yang <turmary@126.com>
+ * Copyright (c) 2019 Seeed Studio
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
  */
 
 /dts-v1/;
@@ -9,42 +13,80 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pinctrl/am33xx.h>
 
-/*
- * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
- */
-&{/chosen} {
-	overlays {
-		PB-BONE-AUDI-02-00A0.bb.org-overlays = __TIMESTAMP__;
-	};
-};
-
 / {
+	/*
+	 * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+	 */
+	fragment@0 {
+		target-path="/";
+		__overlay__ {
+
+			chosen {
+				overlays {
+					PB-I2C2-TLV320AIC3104 = __TIMESTAMP__;
+				};
+			};
+		};
+	};
+
+	#if 0
 	/*
 	 * Free up the pins used by the cape from the pinmux helpers.
 	 */
 	fragment@1 {
 		target = <&ocp>;
 		__overlay__ {
-			P1_29_pinmux { status = "disabled"; };
-			P1_33_pinmux { status = "disabled"; };
-			P1_36_pinmux { status = "disabled"; };
-			P2_02_pinmux { status = "disabled"; };
-			P2_30_pinmux { status = "disabled"; };
-			P2_32_pinmux { status = "disabled"; };
+			P1_29_pinmux { status = "disabled"; };	/* mcasp0_ahclkx */
+			P1_33_pinmux { status = "disabled"; };	/* mcasp0_fsx */
+			P1_36_pinmux { status = "disabled"; };	/* mcasp0_aclkx */
+			P2_30_pinmux { status = "disabled"; };	/* mcasp0_axr2 */
+			P2_32_pinmux { status = "disabled"; };	/* mcasp0_axr0 */
 		};
 	};
+	#endif
 
 	fragment@2 {
 		target = <&am33xx_pinmux>;
 		__overlay__ {
-			bone_audio_cape_audio_pins: pinmux_bone_audio_cape_audio_pins {
+			pinmux_P1_29_default_pin {
 				pinctrl-single,pins = <
-					AM33XX_IOPAD(0x990, PIN_INPUT_PULLDOWN | MUX_MODE0)	/* mcasp0_aclkx.mcasp0_aclkx */
-					AM33XX_IOPAD(0x994, PIN_INPUT_PULLDOWN | MUX_MODE0)	/* mcasp0_fsx.mcasp0_fsx, INPUT */
-					AM33XX_IOPAD(0x998, PIN_INPUT_PULLDOWN | MUX_MODE0)	/* mcasp0_axr0.mcasp0_axr0 */
-					AM33XX_IOPAD(0x99c, PIN_INPUT_PULLDOWN | MUX_MODE2)	/* mcasp0_ahclkr.mcasp0_axr2 */
-					AM33XX_IOPAD(0x9ac, PIN_INPUT_PULLDOWN | MUX_MODE0)	/* MCASP0_AHCLKX -> MCASP0_AHCLKX (I2S_MCLK_OUT)- in */
-					AM33XX_IOPAD(0x86c, PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a11.GPIO1_27 */
+					/* mcasp0_ahclkx.mcasp0_ahclkx */
+					AM33XX_IOPAD(0x09AC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE0)
+				>;
+			};
+
+			pinmux_P1_33_default_pin {
+				pinctrl-single,pins = <
+					/* mcasp0_fsx.mcasp0_fsx */
+					AM33XX_IOPAD(0x0994, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE0)
+				>;
+			};
+
+			pinmux_P1_36_default_pin {
+				pinctrl-single,pins = <
+					/* mcasp0_aclkx.mcasp0_aclkx */
+					AM33XX_IOPAD(0x0990, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE0)
+				>;
+			};
+
+			pinmux_P2_28_default_pin {
+				pinctrl-single,pins = <
+					/* mcasp0_axr1.gpio3_20 */
+					AM33XX_IOPAD(0x09a8, PIN_OUTPUT | INPUT_EN | MUX_MODE7)
+				>;
+			};
+
+			pinmux_P2_30_default_pin {
+				pinctrl-single,pins = <
+					/* mcasp0_ahclkr.mcasp0_axr2 */
+					AM33XX_IOPAD(0x099C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE2)
+				>;
+			};
+
+			pinmux_P2_32_default_pin {
+				pinctrl-single,pins = <
+					/* mcasp0_axr0.mcasp0_axr0 */
+					AM33XX_IOPAD(0x998, PIN_INPUT_PULLDOWN | MUX_MODE0)
 				>;
 			};
 		};
@@ -53,22 +95,9 @@
 	fragment@3 {
 		target-path="/";
 		__overlay__ {
-			clk_mcasp0_fixed: clk_mcasp0_fixed {
-				#clock-cells = <0>;
-				compatible = "fixed-clock";
-				clock-frequency = <24576000>;
-			};
-
-			clk_mcasp0: clk_mcasp0 {
-				#clock-cells = <0>;
-				compatible = "gpio-gate-clock";
-				clocks = <&clk_mcasp0_fixed>;
-				enable-gpios = <&gpio1 27 0>; /* BeagleBone Black Clk enable on GPIO1_27 */
-			};
-
 			sound {
 				compatible = "simple-audio-card";
-				simple-audio-card,name = "AudioCape Rev B";
+				simple-audio-card,name = "TLV320AIC3x Audio Cape for PB";
 				simple-audio-card,widgets =
 					"Headphone", "Headphone Jack",
 					"Line", "Line In";
@@ -77,19 +106,20 @@
 					"Headphone Jack",       "HPROUT",
 					"LINE1L",               "Line In",
 					"LINE1R",               "Line In";
-				simple-audio-card,format = "dsp_b";
+				simple-audio-card,format = "i2s";
 				simple-audio-card,bitclock-master = <&sound_master>;
 				simple-audio-card,frame-master = <&sound_master>;
-				simple-audio-card,bitclock-inversion;
 
-				simple-audio-card,cpu {
+				sound_master: simple-audio-card,cpu {
 					sound-dai = <&mcasp0>;
+					clocks = <&mcasp0_fck>;
+					system-clock-direction-out;
 				};
 
-				sound_master: simple-audio-card,codec {
+				simple-audio-card,codec {
 					#sound-dai-cells = <0>;
 					sound-dai = <&tlv320aic3104>;
-					clocks = <&clk_mcasp0>;
+					clocks = <&mcasp0_fck>;
 					clock-names = "mclk";
 				};
 			};
@@ -108,6 +138,7 @@
 				#sound-dai-cells = <0>;
 				compatible = "ti,tlv320aic3104";
 				reg = <0x18>;
+				gpio-reset = <&gpio3 20 0>;
 			};
 		};
 	};
@@ -116,8 +147,6 @@
 		target = <&mcasp0>;
 		__overlay__ {
 			#sound-dai-cells = <0>;
-			pinctrl-names = "default";
-			pinctrl-0 = <&bone_audio_cape_audio_pins>;
 			status = "okay";
 			op-mode = <0>;	/* MCASP_IIS_MODE */
 			tdm-slots = <2>;
@@ -132,4 +161,21 @@
 			rx-num-evt = <1>;
 		};
 	};
+
+	#if 0
+	/*
+	 * Previous kernels ( < 4.14 ) occupy gpio exclusivly by one driver.
+	 * uncomment below statments to disable cape-universal
+	 * which occupy all expansion gpios.
+	 */
+	fragment@6 {
+		target= <&ocp>;
+		__overlay__ {
+			cape-universal {
+				status = "disabled";
+				/delete-node/P2_28;
+			};
+		};
+	};
+	#endif
 };

--- a/src/arm/PB-I2C2-TLV320AIC3104.dts
+++ b/src/arm/PB-I2C2-TLV320AIC3104.dts
@@ -1,0 +1,181 @@
+/*
+ * Peter Yang <turmary@126.com>
+ * Copyright (c) 2019 Seeed Studio
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+	/*
+	 * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+	 */
+	fragment@0 {
+		target-path="/";
+		__overlay__ {
+
+			chosen {
+				overlays {
+					PB-I2C2-TLV320AIC3104 = __TIMESTAMP__;
+				};
+			};
+		};
+	};
+
+	#if 0
+	/*
+	 * Free up the pins used by the cape from the pinmux helpers.
+	 */
+	fragment@1 {
+		target = <&ocp>;
+		__overlay__ {
+			P1_29_pinmux { status = "disabled"; };	/* mcasp0_ahclkx */
+			P1_33_pinmux { status = "disabled"; };	/* mcasp0_fsx */
+			P1_36_pinmux { status = "disabled"; };	/* mcasp0_aclkx */
+			P2_30_pinmux { status = "disabled"; };	/* mcasp0_axr2 */
+			P2_32_pinmux { status = "disabled"; };	/* mcasp0_axr0 */
+		};
+	};
+	#endif
+
+	fragment@2 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			pinmux_P1_29_default_pin {
+				pinctrl-single,pins = <
+					/* mcasp0_ahclkx.mcasp0_ahclkx */
+					AM33XX_IOPAD(0x09AC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE0)
+				>;
+			};
+
+			pinmux_P1_33_default_pin {
+				pinctrl-single,pins = <
+					/* mcasp0_fsx.mcasp0_fsx */
+					AM33XX_IOPAD(0x0994, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE0)
+				>;
+			};
+
+			pinmux_P1_36_default_pin {
+				pinctrl-single,pins = <
+					/* mcasp0_aclkx.mcasp0_aclkx */
+					AM33XX_IOPAD(0x0990, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE0)
+				>;
+			};
+
+			pinmux_P2_28_default_pin {
+				pinctrl-single,pins = <
+					/* mcasp0_axr1.gpio3_20 */
+					AM33XX_IOPAD(0x09a8, PIN_OUTPUT | INPUT_EN | MUX_MODE7)
+				>;
+			};
+
+			pinmux_P2_30_default_pin {
+				pinctrl-single,pins = <
+					/* mcasp0_ahclkr.mcasp0_axr2 */
+					AM33XX_IOPAD(0x099C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE2)
+				>;
+			};
+
+			pinmux_P2_32_default_pin {
+				pinctrl-single,pins = <
+					/* mcasp0_axr0.mcasp0_axr0 */
+					AM33XX_IOPAD(0x998, PIN_INPUT_PULLDOWN | MUX_MODE0)
+				>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target-path="/";
+		__overlay__ {
+			sound {
+				compatible = "simple-audio-card";
+				simple-audio-card,name = "TLV320AIC3x Audio Cape for PB";
+				simple-audio-card,widgets =
+					"Headphone", "Headphone Jack",
+					"Line", "Line In";
+				simple-audio-card,routing =
+					"Headphone Jack",       "HPLOUT",
+					"Headphone Jack",       "HPROUT",
+					"LINE1L",               "Line In",
+					"LINE1R",               "Line In";
+				simple-audio-card,format = "i2s";
+				simple-audio-card,bitclock-master = <&sound_master>;
+				simple-audio-card,frame-master = <&sound_master>;
+
+				sound_master: simple-audio-card,cpu {
+					sound-dai = <&mcasp0>;
+					clocks = <&mcasp0_fck>;
+					system-clock-direction-out;
+				};
+
+				simple-audio-card,codec {
+					#sound-dai-cells = <0>;
+					sound-dai = <&tlv320aic3104>;
+					clocks = <&mcasp0_fck>;
+					clock-names = "mclk";
+				};
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&i2c2>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <100000>;
+			status = "okay";
+
+			tlv320aic3104: tlv320aic3104@18 {
+				#sound-dai-cells = <0>;
+				compatible = "ti,tlv320aic3104";
+				reg = <0x18>;
+				gpio-reset = <&gpio3 20 0>;
+			};
+		};
+	};
+
+	fragment@5 {
+		target = <&mcasp0>;
+		__overlay__ {
+			#sound-dai-cells = <0>;
+			status = "okay";
+			op-mode = <0>;	/* MCASP_IIS_MODE */
+			tdm-slots = <2>;
+			num-serializer = <16>;
+			serial-dir = <	/* 0: INACTIVE, 1: TX, 2: RX */
+					2 0 1 0
+					0 0 0 0
+					0 0 0 0
+					0 0 0 0
+				>;
+			tx-num-evt = <1>;
+			rx-num-evt = <1>;
+		};
+	};
+
+	#if 0
+	/*
+	 * Previous kernels ( < 4.14 ) occupy gpio exclusivly by one driver.
+	 * uncomment below statments to disable cape-universal
+	 * which occupy all expansion gpios.
+	 */
+	fragment@6 {
+		target= <&ocp>;
+		__overlay__ {
+			cape-universal {
+				status = "disabled";
+				/delete-node/P2_28;
+			};
+		};
+	};
+	#endif
+};


### PR DESCRIPTION
As discussed [here ](https://forum.digikey.com/t/getting-started-with-a-custom-audio-cape/18300/30?u=wesperos), a dts for audio cape on PocketBeagle wont work if we simply copy BB-BONE-AUDI-02-00A0 and change pinmux, It will work if we take the existing dts for the codec (PB-I2C1-TLV320AIC3104) and modify the I2C instance. Here I share the codec dts for i2c2 as well as the audio cape dts.