### PR TITLE
DRAFT: RFC - fix RTC alias for 6.1.x kernel series

### DIFF
--- a/src/arm/BB-I2C2-RTC-DS1338.dts
+++ b/src/arm/BB-I2C2-RTC-DS1338.dts
@@ -50,9 +50,9 @@
 			aliases {
 				rtc0 = &extrtc;
 				/* The OMAP RTC implementation in the BBB is
-				 * buggy, so that it cannot be used as a
-				 * battery-backed RTS, so that it loses its
-				 * contents when power is removed from the
+				 * buggy, and cannot be used as a
+				 * battery-backed time source because it loses
+				 * its contents when power is removed from the
 				 * Beaglebone...
 				 *
 				 * We move the omap built-in RTC to rtc1, so

--- a/src/arm/BB-I2C2-RTC-DS1338.dts
+++ b/src/arm/BB-I2C2-RTC-DS1338.dts
@@ -62,7 +62,7 @@
 				 * is also used during the reboot process on the
 				 * BBB.
 				 */
-				rtc1 = "/ocp/rtc@44e3e000";
+				rtc1 = "/ocp/interconnect@44c00000/segment@200000/target-module@3e000/rtc@0";
 			};
 		};
 	};


### PR DESCRIPTION
DRAFT - RFC 

This device tree overlay (and also various others in the tree which have been derived from it) assign the alias rtc1 to the SoC realtime clock via its device tree path - this makes Debian and the kernel do the right thing with a fully functioning rtc at `/dev/rtc0`.  Between the 4.19.x kernel series and the 6.1.x kernel series, the path for this changed from `/ocp/rtc@44e3e000` to `/ocp/interconnect@44c00000/segment@200000/target-module@3e000/rtc@0`.

This change breaks backward compatibility.  The parent device tree path: `/__symbols__/rtc` points to the correct path in both kernel series, but I don't think it's possible to utilise this in a devicetree overlay.